### PR TITLE
Set proper trace ID field in logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,6 +1662,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-subscriber"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39891c6f2a8e066540984e1050747baa3ad274fd416d2e79dec79f91c6221c33"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-core",
+ "tracing-serde",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,6 +2000,7 @@ dependencies = [
  "gcp_auth",
  "itertools 0.14.0",
  "jiff",
+ "json-subscriber",
  "libmotiva",
  "metrics",
  "metrics-exporter-prometheus",

--- a/crates/motiva/Cargo.toml
+++ b/crates/motiva/Cargo.toml
@@ -65,6 +65,7 @@ gcp_auth = { version = "0.12.3", optional = true }
 metrics = "0.24.2"
 metrics-exporter-prometheus = { version = "0.17.2", default-features = false, features = ["http-listener"] }
 axum-macros = "0.5.0"
+json-subscriber = "0.2.6"
 
 [dev-dependencies]
 axum-test = "18.0.2"

--- a/crates/motiva/src/api/middlewares/logging.rs
+++ b/crates/motiva/src/api/middlewares/logging.rs
@@ -15,25 +15,20 @@ use tokio::time::Instant;
 use tracing::Span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
-use crate::api::{
-  AppState,
-  config::{Config, TracingExporter},
-  middlewares::RequestId,
-};
+use crate::api::{AppState, config::Config};
 
 pub async fn api_logger<P>(State(state): State<AppState<P>>, request: Request<Body>, next: Next) -> Result<Response, StatusCode>
 where
   P: IndexProvider,
 {
   let span = Span::current();
-  let trace_id = trace_id_for_logs(&state.config, span.context().span().span_context().trace_id());
+  let trace_id = span.context().span().span_context().trace_id();
 
   let time = Timestamp::now().strftime("%Y-%m-%dT%H:%M:%S%z").to_string();
   let method = request.method().clone();
   let uri = request.uri().clone();
 
   let (mut parts, body) = request.into_parts();
-  let request_id = parts.extensions.get::<RequestId>().map(|id| id.0).unwrap_or_default();
   let ip = if let Ok(ConnectInfo(addr)) = parts.extract::<ConnectInfo<SocketAddr>>().await {
     addr.ip().to_string()
   } else {
@@ -45,9 +40,10 @@ where
 
   global::meter("motiva").f64_histogram("request_latency").build().record(then.elapsed().as_secs_f64() * 1000.0, &[]);
 
+  let span = add_trace_id(&state.config, trace_id);
+  let _guard = span.enter();
+
   tracing::info!(
-    request_id = %request_id,
-    trace = %trace_id,
     time = time,
     remote = ip,
     method = %method,
@@ -63,10 +59,13 @@ where
   Ok(response)
 }
 
-fn trace_id_for_logs(config: &Config, trace_id: TraceId) -> String {
+fn add_trace_id(config: &Config, trace_id: TraceId) -> Span {
+  #[cfg(feature = "gcp")]
+  use crate::api::config::TracingExporter;
+
   match config.tracing_exporter {
-    TracingExporter::Otlp => trace_id.to_string(),
     #[cfg(feature = "gcp")]
-    TracingExporter::Gcp => format!("projects/{}/traces/{trace_id}", config.gcp_project_id),
+    TracingExporter::Gcp => tracing::info_span!("request", trace_id = ?trace_id, "logging.googleapis.com/trace" = format!("projects/{}/traces/{trace_id}", config.gcp_project_id)),
+    _ => tracing::info_span!("request", trace_id = ?trace_id),
   }
 }

--- a/crates/motiva/src/tests/middlewares.rs
+++ b/crates/motiva/src/tests/middlewares.rs
@@ -135,7 +135,7 @@ rusty_fork_test! {
             assert_eq!(lines.len(), 1);
             assert!(lines[0].contains("POST http://localhost/match/default"));
             assert!(lines[0].contains("request_id="));
-            assert!(lines[0].contains("trace=0af7651916cd43dd8448eb211c80319c"));
+            assert!(lines[0].contains("trace_id=0af7651916cd43dd8448eb211c80319c"));
             assert!(lines[0].contains(r#"remote="-" method=POST path="/match/default" status=415"#));
         });
     }

--- a/crates/motiva/src/trace.rs
+++ b/crates/motiva/src/trace.rs
@@ -35,7 +35,13 @@ pub async fn init_tracing(config: &Config, writer: impl Write + Send + 'static) 
   let formatter = match config.env {
     #[cfg(not(test))]
     Env::Dev => fmt::layer().compact().with_writer(appender).with_ansi(true).boxed(),
-    Env::Production => fmt::layer().json().with_writer(appender).flatten_event(true).with_current_span(false).with_span_list(false).boxed(),
+    Env::Production => json_subscriber::layer()
+      .with_writer(appender)
+      .flatten_event(true)
+      .flatten_span_list_on_top_level(true)
+      .with_current_span(false)
+      .with_span_list(false)
+      .boxed(),
 
     #[cfg(test)]
     Env::Dev => fmt::layer().compact().with_writer(appender).with_ansi(false).boxed(),


### PR DESCRIPTION
Always set `trace_id`, and optionally, on the `gcp` feature, `logging.googleapis.com/trace`.