### PR TITLE
Use an exhaustive list of unicode categories to tokenize names.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1777,6 +1777,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tracing",
+ "unicode-general-category",
  "unicode-normalization",
  "validator",
  "whatlang",
@@ -4062,6 +4063,12 @@ name = "unicase"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+
+[[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
 
 [[package]]
 name = "unicode-ident"

--- a/crates/libmotiva/Cargo.toml
+++ b/crates/libmotiva/Cargo.toml
@@ -59,6 +59,7 @@ whatlang = "0.18.0"
 
 rust_icu_sys = { version = "5.1.0", optional = true }
 rust_icu_utrans = { version = "5.1.0", optional = true }
+unicode-general-category = "1.1.0"
 
 [dev-dependencies]
 criterion = { version = "0.7.0", features = ["async_tokio"] }

--- a/crates/libmotiva/src/matching/matchers/phonetic.rs
+++ b/crates/libmotiva/src/matching/matchers/phonetic.rs
@@ -35,7 +35,7 @@ fn score_feature(&self, bump: &Bump, lhs: &SearchEntity, rhs: &Entity) -> f64 {
         if compare_name_phonetic_tuples((l_name, l_phone.as_deref()), (r_name, r_phone.as_deref())) {
           matched += 1;
 
-          if let Some(index) = comp.iter().position(|x| *x == (r_name, r_phone.clone())) {
+          if let Some(index) = comp.iter().position(|x| *x == (r_name.clone(), r_phone.clone())) {
             comp.remove(index);
           }
 


### PR DESCRIPTION
Names were tokenized from whitespace or dashes, which was far from enough to even reach feature parity with Yente. We now use each character's Unicode category to determine if should be a tokenization split.