### PR TITLE
Allow skipping Elasticsearch TLS verification or set a custom CA chain

### DIFF
--- a/crates/libmotiva/README.md
+++ b/crates/libmotiva/README.md
@@ -60,6 +60,8 @@ Motiva is configured via environment variables. The following variables are supp
 | `INDEX_AUTH_METHOD`        | Elasticsearch authentication (`none`, `basic`, `bearer`, `api_key`, `encoded_api_key`) | `none`                  |
 | `INDEX_CLIENT_ID`          | Elasticsearch client ID (required for `basic` or `api_key`)                            | _(none)_                |
 | `INDEX_CLIENT_SECRET`      | Elasticsearch client secret (required for `basic`, `api_key` or `encoded_api_key`)     | _(none)_                |
+| `INDEX_TLS_CA_CERT`        | Path to a PEM-encoded certificate chain to use for TLS validation                      | _(none)_                |
+| `INDEX_TLS_SKIP_VERIFY`    | If `1`, do not validate the TLS certificate served by the Elasticsearch cluster        | _0_                     |
 | `MANIFEST_URL`             | Optional URL to a custom manifest JSON file                                            | _(none)_                |
 | `CATALOG_REFRESH_INTERVAL` | Interval at which to pull the manifest and catalogs                                    | _1h_                    |
 | `MATCH_CANDIDATES`         | Number of candidates to consider for matching                                          | `10`                    |

--- a/crates/libmotiva/src/index/elastic/builder.rs
+++ b/crates/libmotiva/src/index/elastic/builder.rs
@@ -3,36 +3,21 @@ use anyhow::Context;
 use elasticsearch::cert::{Certificate, CertificateValidation};
 use elasticsearch::http::Url;
 use elasticsearch::http::transport::{SingleNodeConnectionPool, TransportBuilder};
-use elasticsearch::{Elasticsearch, auth::Credentials, http::transport::Transport};
-use std::fs;
+use elasticsearch::{Elasticsearch, auth::Credentials};
 
 impl ElasticsearchProvider {
-  pub async fn new(url: &str, auth: EsAuthMethod, version: Option<IndexVersion>, tls_option: EsTLSOption) -> Result<ElasticsearchProvider, MotivaError> {
+  pub async fn new(url: &str, auth: EsAuthMethod, tls_option: &EsTlsVerification, version: Option<IndexVersion>) -> Result<ElasticsearchProvider, MotivaError> {
     let es = {
-      let parsed_url = Url::parse(url).unwrap();
-      let transport_builder = TransportBuilder::new(
-        SingleNodeConnectionPool::new(parsed_url)
-      );
+      let parsed_url = Url::parse(url).context("invalid index URL")?;
+      let transport_builder = TransportBuilder::new(SingleNodeConnectionPool::new(parsed_url));
+
       let transport = match tls_option {
-        EsTLSOption::None => {
-          Transport::single_node(url)?
-        }
-        EsTLSOption::SkipVerify => {
-          transport_builder
-              .cert_validation(CertificateValidation::None)
-              .build()
-              .context("could not build single node connection pool with SkipVerify ssl option")?
-        }
-        EsTLSOption::CAFilePath(ca_path) => {
-          let pem = fs::read(ca_path.clone()).context(format!("could not read root CA from {}", ca_path))?;
-          let cert = Certificate::from_pem(&pem).context("invalid CA certificate")?;
-          let cert_validation = CertificateValidation::Full(cert);
-          transport_builder
-              .cert_validation(cert_validation)
-              .build()
-              .context("could not build single node connection pool with CAFilePath ssl option")?
-        }
+        EsTlsVerification::Default => transport_builder,
+        EsTlsVerification::SkipVerify => transport_builder.cert_validation(CertificateValidation::None),
+        EsTlsVerification::CaCertChain(pem) => transport_builder.cert_validation(CertificateValidation::Full(Certificate::from_pem(pem)?)),
       };
+
+      let transport = transport.build().context("could not build index client")?;
 
       match auth {
         EsAuthMethod::Basic(username, password) => transport.set_auth(Credentials::Basic(username, password)),
@@ -71,45 +56,56 @@ pub enum EsAuthMethod {
   EncodedApiKey(String),
 }
 
+/// TLS certificate method to use when using an HTTPS URL
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub enum EsTLSOption {
-  // Not using TLS
+pub enum EsTlsVerification {
+  /// Use default TLS certificate validation
   #[default]
-  None,
-  // Skip server certificate verification
+  Default,
+  /// Skip server certificate verification
   SkipVerify,
-  // Inject server CA.crt from file path
-  CAFilePath(String),
+  /// Validate certificate against a provided PEM CA certificate chain
+  CaCertChain(Vec<u8>),
 }
 
 #[cfg(test)]
 mod tests {
+  use crate::index::elastic::builder::EsTlsVerification;
   use crate::{
     index::elastic::version::IndexVersion,
     prelude::{ElasticsearchProvider, EsAuthMethod},
   };
-  use crate::index::elastic::builder::{EsTLSOption};
 
   #[tokio::test]
   async fn es_builder() {
-    let (u, p, ca_path) = ("secret".to_string(), "secret".to_string(), "/etc/ssl/ca.crt".to_string());
+    let (u, p) = ("secret".to_string(), "secret".to_string());
+    let cert = "-----BEGIN CERTIFICATE-----\nMFAwRgIBADADBgEAMAAwHhcNNTAwMTAxMDAwMDAwWhcNNDkxMjMxMjM1OTU5WjAAMBgwCwYJKoZIhvcNAQEBAwkAMAYCAQACAQAwAwYBAAMBAA==\n-----END CERTIFICATE-----";
 
-    ElasticsearchProvider::new("http://url:9200", EsAuthMethod::None, Some(IndexVersion::V4), EsTLSOption::None).await.unwrap();
-    ElasticsearchProvider::new("http://url:9200", EsAuthMethod::Basic(u.clone(), p.clone()), Some(IndexVersion::V4), EsTLSOption::None)
+    ElasticsearchProvider::new("http://url:9200", EsAuthMethod::None, &EsTlsVerification::Default, Some(IndexVersion::V4))
       .await
       .unwrap();
-    ElasticsearchProvider::new("http://url:9200", EsAuthMethod::Bearer(p.clone()), Some(IndexVersion::V4), EsTLSOption::None).await.unwrap();
-    ElasticsearchProvider::new("http://url:9200", EsAuthMethod::ApiKey(u.clone(), p.clone()), Some(IndexVersion::V4), EsTLSOption::None)
+    ElasticsearchProvider::new("http://url:9200", EsAuthMethod::Basic(u.clone(), p.clone()), &EsTlsVerification::Default, Some(IndexVersion::V4))
       .await
       .unwrap();
-    ElasticsearchProvider::new("http://url:9200", EsAuthMethod::EncodedApiKey(p.clone()), Some(IndexVersion::V4), EsTLSOption::None)
+    ElasticsearchProvider::new("http://url:9200", EsAuthMethod::Bearer(p.clone()), &EsTlsVerification::Default, Some(IndexVersion::V4))
       .await
       .unwrap();
-    ElasticsearchProvider::new("https://url:9200", EsAuthMethod::Basic(u.clone(), p.clone()), None, EsTLSOption::SkipVerify)
-        .await
-        .unwrap();
-    ElasticsearchProvider::new("https://url:9200", EsAuthMethod::Basic(u.clone(), p.clone()), None, EsTLSOption::CAFilePath(ca_path.clone()))
-        .await
-        .unwrap();
+    ElasticsearchProvider::new("http://url:9200", EsAuthMethod::ApiKey(u.clone(), p.clone()), &EsTlsVerification::Default, Some(IndexVersion::V4))
+      .await
+      .unwrap();
+    ElasticsearchProvider::new("http://url:9200", EsAuthMethod::EncodedApiKey(p.clone()), &EsTlsVerification::Default, Some(IndexVersion::V4))
+      .await
+      .unwrap();
+    ElasticsearchProvider::new("https://url:9200", EsAuthMethod::Basic(u.clone(), p.clone()), &EsTlsVerification::SkipVerify, Some(IndexVersion::V4))
+      .await
+      .unwrap();
+    ElasticsearchProvider::new(
+      "https://url:9200",
+      EsAuthMethod::Basic(u.clone(), p.clone()),
+      &EsTlsVerification::CaCertChain(cert.as_bytes().to_vec()),
+      Some(IndexVersion::V4),
+    )
+    .await
+    .unwrap();
   }
 }

--- a/crates/libmotiva/src/lib.rs
+++ b/crates/libmotiva/src/lib.rs
@@ -35,7 +35,7 @@ pub mod prelude {
   pub use crate::error::MotivaError;
   pub use crate::index::{
     EntityHandle, IndexProvider,
-    elastic::{ElasticsearchProvider, builder::EsAuthMethod, builder:: EsTLSOption},
+    elastic::{ElasticsearchProvider, builder::EsAuthMethod, builder::EsTlsVerification},
   };
   pub use crate::matching::{Algorithm, Feature, MatchParams, MatchingAlgorithm, logic_v1::LogicV1, name_based::NameBased, name_qualified::NameQualified};
   pub use crate::model::{Entity, HasProperties, SearchEntity};


### PR DESCRIPTION
Summary
This PR introduces the ability to configure the Elasticsearch client with a custom CA certificate or to disable SSL verification entirely. This is particularly useful for environments using self-signed certificates (e.g., homelab setups, local development with TLS enabled) where the default rustls stack does not inherit the host's OS trust store.

Problem
Motiva's current implementation uses Transport::single_node(url), which relies on a default certificate validation strategy. When connecting to an Elasticsearch instance secured with a self-signed CA, the client fails with: invalid peer certificate: UnknownIssuer

Changes
I have refactored the ElasticsearchProvider initialization to use a TransportBuilder. The client now checks for two new environment variables:

CA_CERT_PATH:

Action: If set, the client reads the PEM-encoded certificate from the specified path.

Validation: It performs Full certificate validation using the provided CA.

TRUST_ALL_SSL:

Action: If set to "true", the client disables all certificate validation (CertificateValidation::None).

Use Case: Debugging or internal testing in non-critical environments.

Code Logic
The logic follows a tiered approach:

Priority 1: Explicitly provided CA via CA_CERT_PATH.

Priority 2: Opt-in to insecure mode via TRUST_ALL_SSL.

Default: Standard single-node transport.