### PR TITLE
Fix weak_alias_match trying to perform an exact match.

### DIFF
--- a/crates/libmotiva/src/matching/logic_v1.rs
+++ b/crates/libmotiva/src/matching/logic_v1.rs
@@ -10,7 +10,7 @@ use crate::matching::{
     crypto_wallet::CryptoWalletMatch,
     identifier::IdentifierMatch,
     jaro_winkler::PersonNameJaroWinkler,
-    match_::SimpleMatch,
+    match_::{SimpleMatch, WeakAliasMatch},
     mismatch::{NumbersMismatch, SimpleMismatch, dob_day_disjoint, dob_year_disjoint},
     name_fingerprint_levenshtein::NameFingerprintLevenshtein,
     name_literal_match::NameLiteralMatch,
@@ -45,7 +45,7 @@ static FEATURES: LazyLock<Vec<(&'static dyn Feature, f64)>> = LazyLock::new(|| {
     (IdentifierMatch::new("inn_code_match", &["innCode"], Some(validate_inn)), 0.95),
     (IdentifierMatch::new("bic_code_match", &["bicCode"], Some(validate_bic)), 0.95),
     (SimpleMatch::new("identifier_match", &|e| e.prop_group("identifier"), None), 0.85), // TODO: add cleaning
-    (SimpleMatch::new("weak_alias_match", &|e| e.props(&["weakAlias", "name"]), None), 0.8),
+    (&WeakAliasMatch, 0.8),
   ]
 });
 

--- a/crates/libmotiva/src/matching/matchers/match_.rs
+++ b/crates/libmotiva/src/matching/matchers/match_.rs
@@ -1,9 +1,13 @@
 use std::borrow::Cow;
 
-use bumpalo::Bump;
+use bumpalo::{
+  Bump,
+  collections::{CollectIn, Vec},
+};
+use libmotiva_macros::scoring_feature;
 
 use crate::{
-  matching::{Feature, comparers::is_disjoint},
+  matching::{Feature, comparers::is_disjoint, extractors},
   model::{Entity, HasProperties, SearchEntity},
 };
 
@@ -43,5 +47,86 @@ impl<'e> Feature for SimpleMatch<'e> {
         true => 0.0,
       },
     }
+  }
+}
+
+#[scoring_feature(WeakAliasMatch, name = "weak_alias_match")]
+fn score_feature(&self, bump: &Bump, lhs: &SearchEntity, rhs: &Entity) -> f64 {
+  let lhs_names = extractors::clean_names_light(lhs.prop_group("name").iter()).collect_in::<Vec<_>>(bump);
+  let rhs_names = extractors::clean_names_light(rhs.props(&["weakAlias", "abbreviation"]).iter()).collect_in::<Vec<_>>(bump);
+
+  if lhs_names.is_empty() || rhs_names.is_empty() {
+    return 0.0;
+  }
+
+  match is_disjoint(&lhs_names, &rhs_names) {
+    false => 1.0,
+    true => 0.0,
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use bumpalo::Bump;
+
+  use crate::{
+    Entity, Feature, SearchEntity,
+    matching::matchers::match_::{SimpleMatch, WeakAliasMatch},
+  };
+
+  #[test]
+  fn weak_alias_match() {
+    let lhs = SearchEntity::builder("Company").properties(&[("name", &["bob"])]).build();
+    let rhs = Entity::builder("Company").properties(&[("weakAlias", &["joe", "bob"])]).build();
+
+    let score = WeakAliasMatch.score_feature(&Bump::new(), &lhs, &rhs);
+
+    assert_eq!(score, 1.0);
+
+    let lhs = SearchEntity::builder("Company").properties(&[("name", &["bill"])]).build();
+    let rhs = Entity::builder("Company").properties(&[("weakAlias", &["joe", "bob"])]).build();
+
+    let score = WeakAliasMatch.score_feature(&Bump::new(), &lhs, &rhs);
+
+    assert_eq!(score, 0.0);
+  }
+
+  #[test]
+  fn simple_match() {
+    let lhs = SearchEntity::builder("Company").properties(&[("id", &["12345"])]).build();
+    let rhs = Entity::builder("Company").properties(&[("id", &["1234"])]).build();
+
+    let matcher = SimpleMatch::new("", &|e| e.props(&["id"]), None);
+
+    assert_eq!(matcher.score_feature(&Bump::new(), &lhs, &rhs), 0.0);
+
+    let lhs = SearchEntity::builder("Company").properties(&[("id", &["1234"])]).build();
+    let rhs = Entity::builder("Company").properties(&[("id", &["1234"])]).build();
+
+    let matcher = SimpleMatch::new("", &|e| e.props(&["id"]), None);
+
+    assert_eq!(matcher.score_feature(&Bump::new(), &lhs, &rhs), 1.0);
+  }
+
+  #[test]
+  fn simple_match_with_custom_matcher() {
+    let lhs = SearchEntity::builder("Company").properties(&[("id", &["1234"])]).build();
+    let rhs = Entity::builder("Company").properties(&[("id", &["1234"])]).build();
+
+    fn match_quarter(_: &[String], _: &[String]) -> f64 {
+      0.25
+    }
+
+    fn match_three_quarter(_: &[String], _: &[String]) -> f64 {
+      0.75
+    }
+
+    let matcher = SimpleMatch::new("", &|e| e.props(&["id"]), Some(match_quarter));
+
+    assert_eq!(matcher.score_feature(&Bump::new(), &lhs, &rhs), 0.25);
+
+    let matcher = SimpleMatch::new("", &|e| e.props(&["id"]), Some(match_three_quarter));
+
+    assert_eq!(matcher.score_feature(&Bump::new(), &lhs, &rhs), 0.75);
   }
 }

--- a/crates/motiva/src/tests/api.rs
+++ b/crates/motiva/src/tests/api.rs
@@ -106,7 +106,7 @@ async fn api_algorithms() {
 async fn api_match() {
   let index = MockedElasticsearch::builder()
     .entities(vec![
-      Entity::builder("Person").id("Q7747").properties(&[("name", &["Vladimir Putin"])]).build(),
+      Entity::builder("Person").id("Q7747").properties(&[("name", &["Vladimir Putin"]), ("weakAlias", &["That Guy"])]).build(),
       Entity::builder("Person").id("A1234").properties(&[("name", &["Bob the Builder"])]).build(),
     ])
     .build();
@@ -127,7 +127,7 @@ async fn api_match() {
             "test": {
                 "schema": "Person",
                 "properties": {
-                    "name": ["Vladimir Putin"]
+                    "name": ["Vladimir Putin", "that guy"],
                 }
             }
         }


### PR DESCRIPTION
`weak_alias_match` feature was improperly implemented with `SimpleMatch` making it so it would do literal matching of all names and weak aliases.

Some preprocessing is necessary to provide normalized inputs.

This PR moves it to its own feature.