### PR TITLE
Allow passing some query params in the body

### DIFF
--- a/crates/libmotiva/src/index/elastic/queries.rs
+++ b/crates/libmotiva/src/index/elastic/queries.rs
@@ -305,7 +305,9 @@ async fn build_datasets(catalog: &Arc<RwLock<Catalog>>, filters: &mut Vec<serde_
 
     filters.push(json!({ "terms": { "datasets": datasets } }));
   } else {
-    filters.push(json!({ "terms": { "datasets": scope } }));
+    let datasets: Vec<_> = scope.iter().filter(|dataset| scope.contains(*dataset) && !params.exclude_dataset.iter().contains(*dataset)).collect();
+
+    filters.push(json!({ "terms": { "datasets": datasets } }));
   }
 }
 

--- a/crates/motiva/src/api/dto.rs
+++ b/crates/motiva/src/api/dto.rs
@@ -17,6 +17,20 @@ pub struct GetEntityParams {
 pub(crate) struct Payload {
   #[validate(nested, length(min = 1, message = "at least one query must be provided"))]
   pub queries: HashMap<String, SearchEntity, RandomState>,
+
+  // Some query parameters are duplicated in the request body to overcome URL size limitations
+  #[serde(default)]
+  pub params: PayloadParams,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Validate)]
+pub(crate) struct PayloadParams {
+  #[serde(default)]
+  pub include_datasets: Option<Vec<String>>,
+  #[serde(default)]
+  pub exclude_datasets: Option<Vec<String>>,
+  #[serde(default)]
+  pub exclude_entity_ids: Option<Vec<String>>,
 }
 
 #[derive(Default, Serialize)]

--- a/crates/motiva/src/api/handlers/match_entities.rs
+++ b/crates/motiva/src/api/handlers/match_entities.rs
@@ -29,6 +29,16 @@ pub async fn match_entities<F: CatalogFetcher, P: IndexProvider + 'static>(
   query.scope = scope;
   query.candidate_factor = state.config.match_candidates;
 
+  if let Some(datasets) = body.params.include_datasets {
+    query.include_dataset = datasets;
+  }
+  if let Some(datasets) = body.params.exclude_datasets {
+    query.exclude_dataset = datasets;
+  }
+  if let Some(entity_ids) = body.params.exclude_entity_ids {
+    query.exclude_entity_ids = entity_ids;
+  }
+
   body.queries.iter_mut().for_each(|(_, entity)| {
     entity.precompute();
   });


### PR DESCRIPTION
Some request parameters (especially `include_dataset`, `exclude_dataset` and `exclude_entity_ids` can get very long. Too long to ship through the URL query. This adds the option to add those three parameters in the body, under a `params` field.

```json
{
  "queries": [],
  "params": {
    "include_datasets": [],
    "exclude_datasets": [],
    "exclude_entity_ids": []
  }
}
```