### PR TITLE
Add support for scoped index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,6 +581,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1262,6 +1282,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -1956,6 +1977,7 @@ dependencies = [
  "metrics",
  "opentelemetry",
  "pyo3",
+ "rand 0.10.0",
  "regex",
  "reqwest 0.13.2",
  "rphonetic",
@@ -2118,7 +2140,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "metrics",
  "quanta",
- "rand",
+ "rand 0.9.2",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
@@ -2463,7 +2485,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand",
+ "rand 0.9.2",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -2828,7 +2850,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -2886,6 +2908,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2912,6 +2945,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_xoshiro"
@@ -3184,7 +3223,7 @@ dependencies = [
  "futures-util",
  "http",
  "mime",
- "rand",
+ "rand 0.9.2",
  "thiserror 2.0.18",
 ]
 
@@ -3719,7 +3758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3730,7 +3769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 

--- a/crates/libmotiva/Cargo.toml
+++ b/crates/libmotiva/Cargo.toml
@@ -60,6 +60,7 @@ rust_icu_utrans = { version = "5.1.0", optional = true }
 unicode-general-category = "1.1.0"
 unaccent = "0.1.1"
 serde-jsonlines = "0.7.0"
+rand = "0.10.0"
 
 [dev-dependencies]
 criterion = { version = "0.8.1", features = ["async_tokio"] }

--- a/crates/libmotiva/README.md
+++ b/crates/libmotiva/README.md
@@ -51,26 +51,85 @@ Before v0.5.0, motiva is only compatible with data indexer with Yente v4.x. Star
 
 Motiva is configured via environment variables. The following variables are supported:
 
-| Variable                   | Description                                                                            | Default / Example       |
-| -------------------------- | -------------------------------------------------------------------------------------- | ----------------------- |
-| `ENV`                      | Environment (`dev` or `production`)                                                    | `dev`                   |
-| `LISTEN_ADDR`              | Address to bind the API server                                                         | `0.0.0.0:8000`          |
-| `API_KEY`                  | Bearer token used to authenticate requests                                             | _(none)_                |
-| `INDEX_URL`                | Elasticsearch URL                                                                      | `http://localhost:9200` |
-| `INDEX_AUTH_METHOD`        | Elasticsearch authentication (`none`, `basic`, `bearer`, `api_key`, `encoded_api_key`) | `none`                  |
-| `INDEX_CLIENT_ID`          | Elasticsearch client ID (required for `basic` or `api_key`)                            | _(none)_                |
-| `INDEX_CLIENT_SECRET`      | Elasticsearch client secret (required for `basic`, `api_key` or `encoded_api_key`)     | _(none)_                |
-| `INDEX_TLS_CA_CERT`        | Path to a PEM-encoded certificate chain to use for TLS validation                      | _(none)_                |
-| `INDEX_TLS_SKIP_VERIFY`    | If `1`, do not validate the TLS certificate served by the Elasticsearch cluster        | `0`                     |
-| `MANIFEST_URL`             | Optional URL to a custom manifest JSON file                                            | _(none)_                |
-| `CATALOG_REFRESH_INTERVAL` | Interval at which to pull the manifest and catalogs                                    | _1h_                    |
-| `MATCH_CANDIDATES`         | Number of candidates to consider for matching                                          | `10`                    |
-| `ENABLE_PROMETHEUS`        | Enable Prometheus metrics collection and /metrics endpoint                             | `0`                     |
-| `ENABLE_TRACING`           | Set to `1` to enable tracing                                                           | _(none)_                |
-| `TRACING_EXPORTER`         | Tracing exporter kind (`otlp`, or `gcp` if compiled with the `gcp` feature)            | `otlp`                  |
-| `REQUEST_TIMEOUT`          | Maximum duration for a match request                                                   | _10s_                   |
+| Variable                   | Description                                                                            | Default / Example          |
+| -------------------------- | -------------------------------------------------------------------------------------- | -------------------------- |
+| `ENV`                      | Environment (`dev` or `production`)                                                    | `dev`                      |
+| `LISTEN_ADDR`              | Address to bind the API server                                                         | `0.0.0.0:8000`             |
+| `API_KEY`                  | Bearer token used to authenticate requests                                             | _(none)_                   |
+| `INDEX_URL`                | Elasticsearch URL                                                                      | `http://localhost:9200`    |
+| `INDEX_AUTH_METHOD`        | Elasticsearch authentication (`none`, `basic`, `bearer`, `api_key`, `encoded_api_key`) | `none`                     |
+| `INDEX_CLIENT_ID`          | Elasticsearch client ID (required for `basic` or `api_key`)                            | _(none)_                   |
+| `INDEX_CLIENT_SECRET`      | Elasticsearch client secret (required for `basic`, `api_key` or `encoded_api_key`)     | _(none)_                   |
+| `INDEX_TLS_CA_CERT`        | Path to a PEM-encoded certificate chain to use for TLS validation                      | _(none)_                   |
+| `INDEX_TLS_SKIP_VERIFY`    | If `1`, do not validate the TLS certificate served by the Elasticsearch cluster        | `0`                        |
+| `INDEX_NAME`               | Index prefix under which data was indexed (suffixed by `-entities`)                    | `yente`                    |
+| `MANIFEST_URL`             | Optional URL to a custom manifest JSON file                                            | _(none)_                   |
+| `CATALOG_REFRESH_INTERVAL` | Interval at which to pull the manifest and catalogs                                    | _1h_                       |
+| `MATCH_CANDIDATES`         | Number of candidates to consider for matching                                          | `10`                       |
+| `ENABLE_PROMETHEUS`        | Enable Prometheus metrics collection and /metrics endpoint                             | `0`                        |
+| `ENABLE_TRACING`           | Set to `1` to enable tracing                                                           | _(none)_                   |
+| `TRACING_EXPORTER`         | Tracing exporter kind (`otlp`, or `gcp` if compiled with the `gcp` feature)            | `otlp`                     |
+| `REQUEST_TIMEOUT`          | Maximum duration for a match request                                                   | _10s_                      |
+| `SCOPED_INDEX_QUERY`       | Query used to scope down the index used for match queries                              | [see here](#scoped-index) |
 
 Setting `MANIFEST_FILE` is required if you use a customized dataset list and would like your own manifest to be used for catalog generation. If omitted, the default manifest provided by Yente will be used. It requires either an HTTP URL or a local file path ending in `.json`, `.yml` or `.yaml`.
+
+## Motiva-specific features
+
+### Query options passed in body
+
+Some unbounded-in-size query parameters can be passed in the request body instead of through the URL query. This prevents, for some of them taking in unbounded lists, to overflow the maximum length of URLs. Namely, you can now pass the following parameters in the body:
+
+ * `include_dataset`
+ * `exclude_dataset`
+ * `exclude_entity_ids`
+
+The match endpoint body now takes a `params` object at its root:
+ 
+```json
+{
+  "queries": [...],
+  "params": {
+    "include_datasets": [...],
+    "exclude_datasets": [...],
+    "exclude_entity_ids": [...]
+  }
+}
+```
+
+### Scoped index
+
+Motiva supports generating and using a trimmed down index for match queries, while keeping the full index for entity relation queries. This could allow improving performance of match queries if you are only interested in a subset of it, while keeping the full datasets for queries that are less time-sensitive.
+
+For example, you could have a search index that only contains `Person`'s that have `sanction` in their `topics`, while keeping the full index to retrieve details of an entity, enriched with all its relations. Depending on the query you use for the scoped index, you could see a great reduction in latency and resource consumption.
+
+Motiva can be run with the `create-scoped-index` subcommand, which will take care of creating the scoped index and its aliases. Once it is done, restarting motiva will make it effective.
+
+```bash
+$ motiva create-scoped-index
+2026-03-05T16:56:14.439865Z  INFO libmotiva::index::elastic::scoped: found previous scoped index index="motiva-w4xgo6jh"
+2026-03-05T16:56:14.546981Z  INFO libmotiva::index::elastic::scoped: created new index, starting reindexing data index="motiva-9xtyeclx"
+2026-03-05T16:56:24.030717Z  INFO libmotiva::index::elastic::scoped: reindexed data index="motiva-9xtyeclx"
+2026-03-05T16:56:24.041981Z  INFO libmotiva::index::elastic::scoped: atomically swapped index from="motiva-w4xgo6jh" to="motiva-9xtyeclx"
+2026-03-05T16:56:24.071765Z  INFO libmotiva::index::elastic::scoped: deleted old index index="motiva-w4xgo6jh"
+```
+
+The default scoped query is listed below, but can be customized through `SCOPED_INDEX_QUERY`.
+
+```json
+{
+  "bool": {
+    "must": [
+      { "terms": { "schema": [ "Person", "LegalEntity", "Organization", "Company", "Airplane", "Vessel" ] } },
+      { "term": { "topics": "sanction" } }
+    ]
+  }
+}
+```
+
+The scoped index is not kept automatically in sync with the full index, you would need to run `motiva create-scoped-index` again when you need to update it. We suggest running it after your regular indexing operations.
+
+Once your scoped index is created, you can perform a `/match` request with the Motiva-specific `?index_type=scoped` parameters for the new index to be used.
 
 ## Run
 

--- a/crates/libmotiva/src/error.rs
+++ b/crates/libmotiva/src/error.rs
@@ -2,6 +2,8 @@
 pub enum MotivaError {
   #[error("invalid configuration: {0}")]
   ConfigError(String),
+  #[error("missing index: {0}, make sure you ran the indexer")]
+  MissingIndex(String),
   #[error("resource not found")]
   ResourceNotFound,
   #[error("invalid schema: {0}")]

--- a/crates/libmotiva/src/index/elastic/builder.rs
+++ b/crates/libmotiva/src/index/elastic/builder.rs
@@ -1,17 +1,21 @@
-use crate::{error::MotivaError, index::elastic::version::IndexVersion, prelude::ElasticsearchProvider};
+use crate::index::elastic::config::EsOptions;
+use crate::index::elastic::{DEFAULT_INDEX_PREFIX, SCOPED_INDEX_SUFFIX};
+use crate::{error::MotivaError, index::elastic::config::IndexVersion, prelude::ElasticsearchProvider};
 use anyhow::Context;
 use elasticsearch::cert::{Certificate, CertificateValidation};
 use elasticsearch::http::Url;
 use elasticsearch::http::transport::{SingleNodeConnectionPool, TransportBuilder};
+use elasticsearch::indices::IndicesGetAliasParts;
 use elasticsearch::{Elasticsearch, auth::Credentials};
+use reqwest::StatusCode;
 
 impl ElasticsearchProvider {
-  pub async fn new(url: &str, auth: EsAuthMethod, tls_option: &EsTlsVerification, version: Option<IndexVersion>) -> Result<ElasticsearchProvider, MotivaError> {
+  pub async fn new<'o>(url: &str, options: EsOptions<'o>) -> Result<ElasticsearchProvider, MotivaError> {
     let es = {
       let parsed_url = Url::parse(url).context("invalid index URL")?;
       let transport_builder = TransportBuilder::new(SingleNodeConnectionPool::new(parsed_url));
 
-      let transport = match tls_option {
+      let transport = match options.tls {
         EsTlsVerification::Default => transport_builder,
         EsTlsVerification::SkipVerify => transport_builder.cert_validation(CertificateValidation::None),
         EsTlsVerification::CaCertChain(pem) => transport_builder.cert_validation(CertificateValidation::Full(Certificate::from_pem(pem)?)),
@@ -19,7 +23,7 @@ impl ElasticsearchProvider {
 
       let transport = transport.build().context("could not build index client")?;
 
-      match auth {
+      match options.auth {
         EsAuthMethod::Basic(username, password) => transport.set_auth(Credentials::Basic(username, password)),
         EsAuthMethod::Bearer(token) => transport.set_auth(Credentials::Bearer(token)),
         EsAuthMethod::ApiKey(client_id, client_secret) => transport.set_auth(Credentials::ApiKey(client_id, client_secret)),
@@ -30,13 +34,42 @@ impl ElasticsearchProvider {
       Elasticsearch::new(transport)
     };
 
-    let mut provider = ElasticsearchProvider { es, index_version: IndexVersion::V4 };
+    let index_prefix = options.index_name.unwrap_or_else(|| DEFAULT_INDEX_PREFIX.to_string());
 
-    if version.is_none() {
+    let mut provider = ElasticsearchProvider {
+      es,
+      index_prefix: index_prefix.clone(),
+      index_version: IndexVersion::V4,
+      main_index: format!("{}-entities", index_prefix),
+      scoped_index: None,
+    };
+
+    if options.index_version.is_none() {
       provider.index_version = provider.detect_index_version().await?;
     }
 
+    provider.detect_index().await;
+
     Ok(provider)
+  }
+
+  async fn detect_index(&mut self) {
+    let alias = self
+      .es
+      .indices()
+      .get_alias(IndicesGetAliasParts::Index(&[&self.scoped_alias_name()]))
+      .send()
+      .await
+      .map(|resp| resp.status_code())
+      .unwrap_or(StatusCode::NOT_FOUND);
+
+    if alias == StatusCode::OK {
+      self.scoped_index = Some(self.scoped_alias_name());
+    }
+  }
+
+  pub fn scoped_alias_name(&self) -> String {
+    format!("{}-{SCOPED_INDEX_SUFFIX}", self.index_prefix)
   }
 }
 
@@ -68,44 +101,166 @@ pub enum EsTlsVerification {
   CaCertChain(Vec<u8>),
 }
 
+impl Default for &EsTlsVerification {
+  fn default() -> Self {
+    &EsTlsVerification::Default
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use crate::index::elastic::builder::EsTlsVerification;
+  use crate::index::elastic::config::EsOptions;
   use crate::{
-    index::elastic::version::IndexVersion,
+    index::elastic::config::IndexVersion,
     prelude::{ElasticsearchProvider, EsAuthMethod},
   };
+  use elasticsearch::Elasticsearch;
 
   #[tokio::test]
   async fn es_builder() {
     let (u, p) = ("secret".to_string(), "secret".to_string());
     let cert = "-----BEGIN CERTIFICATE-----\nMFAwRgIBADADBgEAMAAwHhcNNTAwMTAxMDAwMDAwWhcNNDkxMjMxMjM1OTU5WjAAMBgwCwYJKoZIhvcNAQEBAwkAMAYCAQACAQAwAwYBAAMBAA==\n-----END CERTIFICATE-----";
 
-    ElasticsearchProvider::new("http://url:9200", EsAuthMethod::None, &EsTlsVerification::Default, Some(IndexVersion::V4))
-      .await
-      .unwrap();
-    ElasticsearchProvider::new("http://url:9200", EsAuthMethod::Basic(u.clone(), p.clone()), &EsTlsVerification::Default, Some(IndexVersion::V4))
-      .await
-      .unwrap();
-    ElasticsearchProvider::new("http://url:9200", EsAuthMethod::Bearer(p.clone()), &EsTlsVerification::Default, Some(IndexVersion::V4))
-      .await
-      .unwrap();
-    ElasticsearchProvider::new("http://url:9200", EsAuthMethod::ApiKey(u.clone(), p.clone()), &EsTlsVerification::Default, Some(IndexVersion::V4))
-      .await
-      .unwrap();
-    ElasticsearchProvider::new("http://url:9200", EsAuthMethod::EncodedApiKey(p.clone()), &EsTlsVerification::Default, Some(IndexVersion::V4))
-      .await
-      .unwrap();
-    ElasticsearchProvider::new("https://url:9200", EsAuthMethod::Basic(u.clone(), p.clone()), &EsTlsVerification::SkipVerify, Some(IndexVersion::V4))
-      .await
-      .unwrap();
     ElasticsearchProvider::new(
-      "https://url:9200",
-      EsAuthMethod::Basic(u.clone(), p.clone()),
-      &EsTlsVerification::CaCertChain(cert.as_bytes().to_vec()),
-      Some(IndexVersion::V4),
+      "http://url:9200",
+      EsOptions {
+        index_version: Some(IndexVersion::V4),
+        ..Default::default()
+      },
     )
     .await
     .unwrap();
+
+    ElasticsearchProvider::new(
+      "http://url:9200",
+      EsOptions {
+        auth: EsAuthMethod::Basic(u.clone(), p.clone()),
+        index_version: Some(IndexVersion::V4),
+        ..Default::default()
+      },
+    )
+    .await
+    .unwrap();
+
+    ElasticsearchProvider::new(
+      "http://url:9200",
+      EsOptions {
+        auth: EsAuthMethod::Bearer(p.clone()),
+        index_version: Some(IndexVersion::V4),
+        ..Default::default()
+      },
+    )
+    .await
+    .unwrap();
+
+    ElasticsearchProvider::new(
+      "http://url:9200",
+      EsOptions {
+        auth: EsAuthMethod::ApiKey(u.clone(), p.clone()),
+        index_version: Some(IndexVersion::V4),
+        ..Default::default()
+      },
+    )
+    .await
+    .unwrap();
+
+    ElasticsearchProvider::new(
+      "http://url:9200",
+      EsOptions {
+        auth: EsAuthMethod::EncodedApiKey(p.clone()),
+        index_version: Some(IndexVersion::V4),
+        ..Default::default()
+      },
+    )
+    .await
+    .unwrap();
+
+    ElasticsearchProvider::new(
+      "https://url:9200",
+      EsOptions {
+        auth: EsAuthMethod::Basic(u.clone(), p.clone()),
+        tls: &EsTlsVerification::SkipVerify,
+        index_version: Some(IndexVersion::V4),
+        ..Default::default()
+      },
+    )
+    .await
+    .unwrap();
+
+    ElasticsearchProvider::new(
+      "https://url:9200",
+      EsOptions {
+        auth: EsAuthMethod::Basic(u.clone(), p.clone()),
+        tls: &EsTlsVerification::CaCertChain(cert.as_bytes().to_vec()),
+        index_version: Some(IndexVersion::V4),
+        ..Default::default()
+      },
+    )
+    .await
+    .unwrap();
+  }
+
+  #[tokio::test]
+  async fn es_builder_default_index_name() {
+    let provider = ElasticsearchProvider::new(
+      "http://url:9200",
+      EsOptions {
+        index_version: Some(IndexVersion::V4),
+        ..Default::default()
+      },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(provider.index_prefix, "yente");
+    assert_eq!(provider.main_index, "yente-entities");
+    assert_eq!(provider.scoped_index, None);
+  }
+
+  #[tokio::test]
+  async fn es_builder_custom_index_name() {
+    let provider = ElasticsearchProvider::new(
+      "http://url:9200",
+      EsOptions {
+        index_name: Some("custom".to_string()),
+        index_version: Some(IndexVersion::V4),
+        ..Default::default()
+      },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(provider.index_prefix, "custom");
+    assert_eq!(provider.main_index, "custom-entities");
+    assert_eq!(provider.scoped_index, None);
+  }
+
+  #[test]
+  fn alias_names_use_prefix() {
+    let provider = ElasticsearchProvider {
+      es: Elasticsearch::default(),
+      index_version: IndexVersion::V4,
+      index_prefix: "mydata".to_string(),
+      main_index: "mydata-entities".to_string(),
+      scoped_index: None,
+    };
+
+    assert_eq!(provider.main_index, "mydata-entities");
+    assert_eq!(provider.scoped_alias_name(), "mydata-motiva-scoped-entities");
+  }
+
+  #[test]
+  fn alias_names_default_prefix() {
+    let provider = ElasticsearchProvider {
+      es: Elasticsearch::default(),
+      index_version: IndexVersion::V4,
+      index_prefix: "yente".to_string(),
+      main_index: "yente-entities".to_string(),
+      scoped_index: None,
+    };
+
+    assert_eq!(provider.main_index, "yente-entities");
+    assert_eq!(provider.scoped_alias_name(), "yente-motiva-scoped-entities");
   }
 }

--- a/crates/libmotiva/src/index/elastic/config.rs
+++ b/crates/libmotiva/src/index/elastic/config.rs
@@ -2,9 +2,18 @@ use std::fmt::Display;
 
 use ahash::HashMap;
 use elasticsearch::indices::IndicesGetMappingParts;
+use reqwest::StatusCode;
 use serde::Deserialize;
 
-use crate::{ElasticsearchProvider, MotivaError};
+use crate::{ElasticsearchProvider, EsAuthMethod, EsTlsVerification, MotivaError};
+
+#[derive(Default)]
+pub struct EsOptions<'o> {
+  pub auth: EsAuthMethod,
+  pub tls: &'o EsTlsVerification,
+  pub index_version: Option<IndexVersion>,
+  pub index_name: Option<String>,
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum IndexVersion {
@@ -43,7 +52,13 @@ pub(crate) struct MappingIndexSource {
 
 impl ElasticsearchProvider {
   pub(crate) async fn detect_index_version(&self) -> Result<IndexVersion, MotivaError> {
-    let mappings: HashMap<String, MappingIndex> = self.es.indices().get_mapping(IndicesGetMappingParts::Index(&["yente-entities"])).send().await?.json().await?;
+    let mappings = self.es.indices().get_mapping(IndicesGetMappingParts::Index(&[&self.main_index])).send().await?;
+
+    if mappings.status_code() != StatusCode::OK {
+      Err(MotivaError::MissingIndex(self.main_index.to_string()))?
+    }
+
+    let mappings: HashMap<String, MappingIndex> = mappings.json().await?;
 
     for (_, index) in mappings {
       if index.mappings.source.excludes.contains(&"name_symbols".to_string()) {

--- a/crates/libmotiva/src/index/elastic/mod.rs
+++ b/crates/libmotiva/src/index/elastic/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod builder;
+pub(crate) mod config;
 pub(crate) mod queries;
-pub(crate) mod version;
+pub(crate) mod scoped;
 
 use std::{collections::HashMap, fmt::Debug};
 
@@ -10,16 +11,34 @@ use jiff::civil::DateTime;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-  index::elastic::version::IndexVersion,
+  index::elastic::config::IndexVersion,
+  matching::IndexType,
   model::{Entity, Properties, Schema},
   schemas::SCHEMAS,
 };
+
+const DEFAULT_INDEX_PREFIX: &str = "yente";
+const SCOPED_INDEX_SUFFIX: &str = "motiva-scoped-entities";
 
 /// Main index provider using Elasticsearch
 #[derive(Clone)]
 pub struct ElasticsearchProvider {
   pub es: Elasticsearch,
   pub(crate) index_version: IndexVersion,
+  pub(crate) index_prefix: String,
+  pub(crate) main_index: String,
+  pub(crate) scoped_index: Option<String>,
+}
+
+impl ElasticsearchProvider {
+  #[inline]
+  pub fn index_name(&self, kind: IndexType) -> &str {
+    match (kind, &self.scoped_index) {
+      (IndexType::Main, _) => &self.main_index,
+      (IndexType::Scoped, None) => &self.main_index,
+      (IndexType::Scoped, Some(scoped_index)) => scoped_index,
+    }
+  }
 }
 
 #[derive(Deserialize)]
@@ -130,8 +149,12 @@ pub(crate) struct EsEntitySource {
 mod tests {
   use std::collections::HashMap;
 
+  use elasticsearch::Elasticsearch;
+
   use crate::{
-    index::elastic::{EsEntity, EsEntitySource},
+    ElasticsearchProvider,
+    index::elastic::{EsEntity, EsEntitySource, config::IndexVersion},
+    matching::IndexType,
     model::{Entity, HasProperties, Schema},
   };
 
@@ -155,6 +178,25 @@ mod tests {
         },
       },
     }
+  }
+
+  #[test]
+  fn build_index_name() {
+    let mut p = ElasticsearchProvider {
+      es: Elasticsearch::default(),
+      index_version: IndexVersion::V5,
+      index_prefix: "myprefix".to_string(),
+      main_index: "myprefix-entities".to_string(),
+      scoped_index: None,
+    };
+
+    assert_eq!(p.index_name(IndexType::Main), "myprefix-entities");
+    assert_eq!(p.index_name(IndexType::Scoped), "myprefix-entities");
+
+    p.scoped_index = Some("myprefix-motiva-scoped-entities".to_string());
+
+    assert_eq!(p.index_name(IndexType::Main), "myprefix-entities");
+    assert_eq!(p.index_name(IndexType::Scoped), "myprefix-motiva-scoped-entities");
   }
 
   #[test]

--- a/crates/libmotiva/src/index/elastic/queries.rs
+++ b/crates/libmotiva/src/index/elastic/queries.rs
@@ -21,7 +21,7 @@ use crate::{
   error::MotivaError,
   index::{
     EntityHandle, IndexProvider,
-    elastic::{EsEntity, EsErrorResponse, EsHealth, EsResponse, version::IndexVersion},
+    elastic::{EsEntity, EsErrorResponse, EsHealth, EsResponse, config::IndexVersion},
   },
   matching::{MatchParams, extractors},
   model::{Entity, ResolveSchemaLevel, SearchEntity},
@@ -31,6 +31,10 @@ use crate::{
 };
 
 impl IndexProvider for ElasticsearchProvider {
+  fn after_init(&self) {
+    tracing::info!(version = ?self.index_version, scoped_index = self.scoped_index, main_index = self.main_index, "detected yente version and index name");
+  }
+
   fn index_version(&self) -> IndexVersion {
     self.index_version
   }
@@ -43,7 +47,7 @@ impl IndexProvider for ElasticsearchProvider {
     let Ok(health) = self
       .es
       .cluster()
-      .health(ClusterHealthParts::Index(&["yente-entities"]))
+      .health(ClusterHealthParts::Index(&[&self.main_index]))
       .send()
       .await
       .context("could not get cluster health")
@@ -70,7 +74,7 @@ impl IndexProvider for ElasticsearchProvider {
 
     let response = self
       .es
-      .search(SearchParts::Index(&["yente-entities"]))
+      .search(SearchParts::Index(&[self.index_name(params.index_type)]))
       .from(0)
       .size(params.candidate_limit() as i64)
       .search_type(SearchType::DfsQueryThenFetch)
@@ -126,7 +130,7 @@ impl IndexProvider for ElasticsearchProvider {
       ]
     });
 
-    let response = self.es.search(SearchParts::Index(&["yente-entities"])).from(0).size(1).body(query).send().await?;
+    let response = self.es.search(SearchParts::Index(&[&self.main_index])).from(0).size(1).body(query).send().await?;
 
     if response.status_code() != StatusCode::OK {
       let body: EsErrorResponse = response.json().await?;
@@ -178,7 +182,7 @@ impl IndexProvider for ElasticsearchProvider {
       }
     });
 
-    let response = self.es.search(SearchParts::Index(&["yente-entities"])).from(0).size(RELATED_ENTITIES_LIMIT).body(query).send().await?;
+    let response = self.es.search(SearchParts::Index(&[&self.main_index])).from(0).size(RELATED_ENTITIES_LIMIT).body(query).send().await?;
 
     if response.status_code() != StatusCode::OK {
       let body: EsErrorResponse = response.json().await?;
@@ -207,7 +211,7 @@ impl IndexProvider for ElasticsearchProvider {
   }
 
   async fn list_indices(&self) -> Result<Vec<(String, String)>, MotivaError> {
-    let indices: HashMap<String, serde_json::Value> = self.es.indices().get_alias(IndicesGetAliasParts::Name(&["yente-entities"])).send().await?.json().await?;
+    let indices: HashMap<String, serde_json::Value> = self.es.indices().get_alias(IndicesGetAliasParts::Name(&[&self.main_index])).send().await?.json().await?;
 
     Ok(parse_index_dataset_versions(indices))
   }
@@ -473,7 +477,7 @@ mod tests {
   use serde_json_assert::{assert_json_contains, assert_json_eq, assert_json_include};
   use tokio::sync::RwLock;
 
-  use crate::{Catalog, catalog::CatalogDataset, index::elastic::version::IndexVersion, model::SearchEntity, prelude::MatchParams};
+  use crate::{Catalog, catalog::CatalogDataset, index::elastic::config::IndexVersion, model::SearchEntity, prelude::MatchParams};
 
   fn fake_catalog() -> Arc<RwLock<Catalog>> {
     Arc::new(RwLock::new({

--- a/crates/libmotiva/src/index/elastic/scoped.rs
+++ b/crates/libmotiva/src/index/elastic/scoped.rs
@@ -1,0 +1,104 @@
+use std::collections::HashMap;
+
+use anyhow::Context;
+use elasticsearch::indices::{IndicesCreateParts, IndicesDeleteParts, IndicesGetAliasParts, IndicesGetParts};
+use rand::distr::{Alphanumeric, SampleString};
+use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::ElasticsearchProvider;
+
+type IndexResponse = HashMap<String, Index>;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct Index {
+  mappings: serde_json::Value,
+  settings: serde_json::Value,
+}
+
+pub async fn create_scoped_index(provider: &ElasticsearchProvider, query: serde_json::Value) -> Result<(), anyhow::Error> {
+  let new_index = format!("motiva-{}", Alphanumeric.sample_string(&mut rand::rng(), 8).to_lowercase());
+
+  let mut actions: Vec<serde_json::Value> = vec![json!({ "add": { "alias": provider.scoped_alias_name(), "index": new_index } })];
+  let mut old_index: Option<String> = None;
+
+  let aliases = provider.es.indices().get_alias(IndicesGetAliasParts::Name(&[&provider.scoped_alias_name()])).send().await?;
+
+  if aliases.status_code() == StatusCode::OK {
+    let aliases: HashMap<String, serde_json::Value> = aliases.json().await?;
+    let previous_index = aliases.keys().next().ok_or_else(|| anyhow::anyhow!("found no alias"))?;
+
+    tracing::info!(index = previous_index, "found previous scoped index");
+
+    actions.push(json!({ "remove": { "alias": provider.scoped_alias_name(), "index": previous_index, "must_exist": true } }));
+    old_index = Some(previous_index.clone());
+  }
+
+  let indices: IndexResponse = provider.es.indices().get(IndicesGetParts::Index(&[&provider.main_index])).send().await?.json().await?;
+  let mut index = indices.values().next().ok_or_else(|| anyhow::anyhow!("found no index"))?.to_owned();
+
+  let nested = index.settings.get_mut("index").context("no settings")?.as_object_mut().context("no settings")?;
+  nested.remove("uuid");
+  nested.remove("provided_name");
+  nested.remove("version");
+  nested.remove("creation_date");
+
+  let response = provider.es.indices().create(IndicesCreateParts::Index(&new_index)).body(index).send().await?;
+  if response.status_code() != StatusCode::OK {
+    anyhow::bail!("index creation returned {}: {:?}", response.status_code(), response.text().await);
+  }
+
+  tracing::info!(index = new_index, "created new index, starting reindexing data");
+
+  let result: Result<(), anyhow::Error> = async {
+    let reindex = provider
+      .es
+      .reindex()
+      .body(json!({
+        "dest": {
+          "index": new_index
+        },
+        "source": {
+          "index": provider.main_index,
+          "query": query,
+        }
+      }))
+      .wait_for_completion(true)
+      .send()
+      .await?;
+
+    if reindex.status_code() != StatusCode::OK {
+      anyhow::bail!("reindex returned {}: {:?}", reindex.status_code(), reindex.text().await);
+    }
+
+    tracing::info!(index = new_index, "reindexed data");
+
+    let response = provider.es.indices().update_aliases().body(json!({ "actions": actions })).send().await?;
+    if response.status_code() != StatusCode::OK {
+      anyhow::bail!("update aliases returned {}: {:?}", response.status_code(), response.text().await);
+    }
+
+    Ok(())
+  }
+  .await;
+
+  if let Err(e) = result {
+    if let Err(err) = provider.es.indices().delete(IndicesDeleteParts::Index(&[&new_index])).send().await {
+      tracing::warn!(index = new_index, error = %err, "failed to clean up orphaned index after error");
+    }
+    return Err(e);
+  }
+
+  tracing::info!(from = old_index, to = new_index, "atomically swapped index");
+
+  if let Some(ref to_delete) = old_index {
+    if provider.es.indices().delete(IndicesDeleteParts::Index(&[to_delete])).send().await?.status_code() != StatusCode::OK {
+      tracing::warn!(index = to_delete, "could not delete previous scoped index, it may need manual cleanup");
+    } else {
+      tracing::info!(index = to_delete, "deleted old index");
+    }
+  }
+
+  Ok(())
+}

--- a/crates/libmotiva/src/index/mock.rs
+++ b/crates/libmotiva/src/index/mock.rs
@@ -7,7 +7,7 @@ use tokio::sync::RwLock;
 use crate::{
   Catalog,
   error::MotivaError,
-  index::{EntityHandle, IndexProvider, elastic::version::IndexVersion},
+  index::{EntityHandle, IndexProvider, elastic::config::IndexVersion},
   matching::MatchParams,
   model::{Entity, SearchEntity},
 };

--- a/crates/libmotiva/src/index/mod.rs
+++ b/crates/libmotiva/src/index/mod.rs
@@ -9,13 +9,15 @@ use tokio::sync::RwLock;
 use crate::{
   Catalog,
   error::MotivaError,
-  index::elastic::version::IndexVersion,
+  index::elastic::config::IndexVersion,
   matching::MatchParams,
   model::{Entity, SearchEntity},
 };
 
 #[allow(async_fn_in_trait)]
 pub trait IndexProvider: Clone + Send + Sync + 'static {
+  fn after_init(&self) {}
+
   fn index_version(&self) -> IndexVersion;
   fn health(&self) -> impl Future<Output = Result<bool, MotivaError>> + Send;
   fn get_entity(&self, id: &str) -> impl Future<Output = Result<EntityHandle, MotivaError>> + Send;

--- a/crates/libmotiva/src/lib.rs
+++ b/crates/libmotiva/src/lib.rs
@@ -35,7 +35,7 @@ pub mod prelude {
   pub use crate::error::MotivaError;
   pub use crate::index::{
     EntityHandle, IndexProvider,
-    elastic::{ElasticsearchProvider, builder::EsAuthMethod, builder::EsTlsVerification},
+    elastic::{ElasticsearchProvider, builder::EsAuthMethod, builder::EsTlsVerification, config::EsOptions, scoped::create_scoped_index},
   };
   pub use crate::matching::{Algorithm, Feature, MatchParams, MatchingAlgorithm, logic_v1::LogicV1, name_based::NameBased, name_qualified::NameQualified};
   pub use crate::model::{Entity, HasProperties, SearchEntity};

--- a/crates/libmotiva/src/matching/mod.rs
+++ b/crates/libmotiva/src/matching/mod.rs
@@ -137,6 +137,20 @@ pub struct MatchParams {
   /// List of schema to exclude from the search.
   #[serde(default)]
   pub exclude_schema: Vec<String>,
+
+  // Motiva-specific params
+  #[serde(default)]
+  pub index_type: IndexType,
+}
+
+/// Variant of the index to use.
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Default, Deserialize)]
+pub enum IndexType {
+  #[default]
+  #[serde(rename = "main")]
+  Main,
+  #[serde(rename = "scoped")]
+  Scoped,
 }
 
 impl MatchParams {
@@ -153,6 +167,7 @@ impl MatchParams {
 #[cfg(test)]
 mod testing {
   use crate::Algorithm;
+  use crate::matching::{IndexType, MatchParams};
 
   #[test]
   fn default_algorithm() {
@@ -166,5 +181,24 @@ mod testing {
     for (alg, name) in [(NameBased, "name-based"), (NameQualified, "name-qualified"), (LogicV1, "logic-v1"), (Best, "best")] {
       assert_eq!(alg.name(), name);
     }
+  }
+
+  #[test]
+  fn index_type_deserialize() {
+    assert_eq!(serde_json::from_str::<IndexType>(r#""main""#).unwrap(), IndexType::Main);
+    assert_eq!(serde_json::from_str::<IndexType>(r#""scoped""#).unwrap(), IndexType::Scoped);
+    assert!(serde_json::from_str::<IndexType>(r#""unknown""#).is_err());
+  }
+
+  #[test]
+  fn match_params_index_type_defaults_to_main() {
+    let params: MatchParams = serde_json::from_str("{}").unwrap();
+    assert_eq!(params.index_type, IndexType::Main);
+  }
+
+  #[test]
+  fn match_params_index_type_parses_scoped() {
+    let params: MatchParams = serde_json::from_str(r#"{"index_type":"scoped"}"#).unwrap();
+    assert_eq!(params.index_type, IndexType::Scoped);
   }
 }

--- a/crates/libmotiva/src/motiva.rs
+++ b/crates/libmotiva/src/motiva.rs
@@ -10,7 +10,7 @@ use crate::{
   catalog::{Catalog, get_merged_catalog},
   error::MotivaError,
   fetcher::CatalogFetcher,
-  index::{EntityHandle, IndexProvider, elastic::version::IndexVersion},
+  index::{EntityHandle, IndexProvider, elastic::config::IndexVersion},
   matching::MatchParams,
   model::{Entity, SearchEntity},
   nested::fetch_nested_entities,
@@ -88,10 +88,10 @@ impl<P: IndexProvider> Motiva<P> {
   pub async fn _new(#[builder(start_fn)] provider: P, #[builder(default)] config: MotivaConfig) -> Result<Motiva<P, HttpCatalogFetcher>, MotivaError> {
     crate::init();
 
+    provider.after_init();
+
     let fetcher = HttpCatalogFetcher::default();
     let catalog = get_merged_catalog(&fetcher, &provider, config.outdated_grace).await.context("could not initialize manifest")?;
-
-    tracing::info!(version = ?provider.index_version(), "detected yente version used from index");
 
     Ok(Motiva {
       config,
@@ -105,9 +105,9 @@ impl<P: IndexProvider> Motiva<P> {
   pub async fn custom<F: CatalogFetcher>(#[builder(start_fn)] provider: P, fetcher: F, #[builder(default)] config: MotivaConfig) -> Result<Motiva<P, F>, MotivaError> {
     crate::init();
 
-    let catalog = get_merged_catalog(&fetcher, &provider, config.outdated_grace).await.context("could not initialize manifest")?;
+    provider.after_init();
 
-    tracing::info!(version = ?provider.index_version(), "detected yente version used from index");
+    let catalog = get_merged_catalog(&fetcher, &provider, config.outdated_grace).await.context("could not initialize manifest")?;
 
     Ok(Motiva {
       config,

--- a/crates/motiva/src/api/config.rs
+++ b/crates/motiva/src/api/config.rs
@@ -21,6 +21,7 @@ pub struct Config {
   pub index_url: String,
   pub index_auth_method: EsAuthMethod,
   pub index_tls_verification: EsTlsVerification,
+  pub index_name: Option<String>,
 
   // Timeouts
   pub request_timeout: Span,
@@ -53,6 +54,7 @@ impl Config {
       index_url: env::var("INDEX_URL").unwrap_or("http://localhost:9200".into()),
       index_auth_method: env::var("INDEX_AUTH_METHOD").unwrap_or("none".into()).parse::<WrappedEsAuthMethod>()?.0,
       index_tls_verification: parse_index_tls_verification()?,
+      index_name: env::var("INDEX_NAME").ok(),
       enable_prometheus: env::var("ENABLE_PROMETHEUS").unwrap_or_default() == "1",
       enable_tracing: env::var("ENABLE_TRACING").unwrap_or_default() == "1",
       tracing_exporter: env::var("TRACING_EXPORTER").unwrap_or("otlp".into()).parse()?,

--- a/crates/motiva/src/api/errors.rs
+++ b/crates/motiva/src/api/errors.rs
@@ -38,6 +38,7 @@ impl From<MotivaError> for AppError {
   fn from(value: MotivaError) -> Self {
     match value {
       MotivaError::ConfigError(err) => AppError::ConfigError(err),
+      MotivaError::MissingIndex(_) => AppError::ServerError,
       MotivaError::IndexError(err) => AppError::IndexError(err.to_string()),
       MotivaError::InvalidSchema(_) => AppError::BadRequest,
       MotivaError::ResourceNotFound => AppError::ResourceNotFound,

--- a/crates/motiva/src/main.rs
+++ b/crates/motiva/src/main.rs
@@ -1,10 +1,11 @@
 mod api;
+mod oneoff;
 mod trace;
 
 #[cfg(test)]
 mod tests;
 
-use libmotiva::{ElasticsearchProvider, HttpCatalogFetcher, IndexProvider};
+use libmotiva::{ElasticsearchProvider, EsOptions, HttpCatalogFetcher, IndexProvider};
 use rustls::crypto::aws_lc_rs;
 use tokio::signal;
 
@@ -18,7 +19,26 @@ async fn main() -> anyhow::Result<()> {
   aws_lc_rs::default_provider().install_default().expect("could not install default cryptography provider");
 
   let config = Config::from_env().await?;
-  let provider = ElasticsearchProvider::new(&config.index_url, config.index_auth_method.clone(), &config.index_tls_verification, None).await?;
+
+  let options = EsOptions {
+    auth: config.index_auth_method.clone(),
+    tls: &config.index_tls_verification,
+    index_name: config.index_name.clone(),
+    ..Default::default()
+  };
+
+  let provider = ElasticsearchProvider::new(&config.index_url, options).await?;
+
+  if let Some(cmd) = std::env::args().nth(1) {
+    let _guards = trace::init_tracing(&config, std::io::stdout()).await;
+
+    match cmd.as_str() {
+      "create-scoped-index" => oneoff::create_scoped_index(&provider).await?,
+      _ => anyhow::bail!("unsupported command `{cmd}`"),
+    }
+
+    return Ok(());
+  }
 
   run(config, provider).await
 }

--- a/crates/motiva/src/oneoff.rs
+++ b/crates/motiva/src/oneoff.rs
@@ -1,0 +1,27 @@
+use std::env;
+
+use libmotiva::ElasticsearchProvider;
+use serde_json::json;
+
+pub async fn create_scoped_index(provider: &ElasticsearchProvider) -> Result<(), anyhow::Error> {
+  let mut query = json!({
+    "bool": {
+      "must": [
+        { "terms": { "schema": ["Person", "LegalEntity", "Organization", "Company", "Airplane", "Vessel"] } },
+        { "term": { "topics": "sanction" } }
+      ]
+    }
+  });
+
+  if let Ok(custom) = env::var("SCOPED_INDEX_QUERY") {
+    query = serde_json::from_str(&custom)?;
+  }
+
+  let result = libmotiva::create_scoped_index(provider, query).await;
+
+  if let Err(ref err) = result {
+    tracing::error!(error = ?err, "encountered error while creating scoped index");
+  }
+
+  result
+}


### PR DESCRIPTION
A new subcommand, `create-scoped-index`, can be used to clone the index into a scoped-down version of itself, containing only entities that will be matched against, to optimize for speed and resource consumption.

The full index is still used for entity retrieval and nested entities graph operations.

On startup, motiva detects whether the scoped alias exists, and adapts its queries accordingly. If the alias does not exist, the old behavior remains and the full index is used.

The PR also adds a configuration setting to set the name of the full index to use (defaults to `yente-entities`).