### PR TITLE
Remove non-ASCII-alpahabetic characters before Metaphone encoding.

### DIFF
--- a/crates/libmotiva/src/matching/extractors.rs
+++ b/crates/libmotiva/src/matching/extractors.rs
@@ -1,6 +1,5 @@
 use std::{borrow::Borrow, sync::LazyLock};
 
-use any_ascii::any_ascii;
 use itertools::Itertools;
 use regex::Regex;
 use rphonetic::{Encoder, Metaphone};
@@ -167,7 +166,7 @@ where
   I: Iterator<Item = &'s S> + 's,
 {
   tokenize_names(names)
-    .flat_map(|s| s.into_iter().filter(|s| is_modern_alphabet(s) && s.chars().count() >= 3).map(|s| METAPHONE.encode(&any_ascii(&s))))
+    .flat_map(|s| s.into_iter().filter(|s| is_modern_alphabet(s) && s.chars().count() >= 3).map(|s| METAPHONE.encode(&latinize(&s))))
     .filter(|phoneme| phoneme.len() > 2)
 }
 
@@ -181,7 +180,7 @@ where
       s.into_iter()
         .filter(|name| name.len() >= 2)
         .map(|s| {
-          let phoneme = METAPHONE.encode(&s);
+          let phoneme = METAPHONE.encode(&latinize(&s));
 
           (s, { if phoneme.len() < 3 { None } else { Some(phoneme) } })
         })

--- a/crates/libmotiva/src/matching/latinize.rs
+++ b/crates/libmotiva/src/matching/latinize.rs
@@ -22,7 +22,11 @@ pub(crate) fn latinize(value: &str) -> String {
     return value.to_string();
   }
 
-  TRANSLITERATOR.with(|t| t.transliterate(value).unwrap_or_else(|_| value.to_string()))
+  TRANSLITERATOR.with(|t| {
+    t.transliterate(value)
+      .map(|s| s.chars().filter(|c| c.is_whitespace() || c.is_ascii_alphabetic()).collect::<String>())
+      .unwrap_or_else(|_| value.chars().filter(|c| c.is_whitespace() || c.is_ascii_alphabetic()).collect::<String>())
+  })
 }
 
 #[cfg(not(feature = "icu"))]


### PR DESCRIPTION
On the `icu` feature, this could cause 500s when libicu was not able to transliterate some characters.