### PR TITLE
Improve enrichment relation ordering, and add settings to tweak effort.

### DIFF
--- a/crates/libmotiva/README.md
+++ b/crates/libmotiva/README.md
@@ -51,25 +51,27 @@ Before v0.5.0, motiva is only compatible with data indexer with Yente v4.x. Star
 
 Motiva is configured via environment variables. The following variables are supported:
 
-| Variable                   | Description                                                                            | Default / Example          |
-| -------------------------- | -------------------------------------------------------------------------------------- | -------------------------- |
-| `ENV`                      | Environment (`dev` or `production`)                                                    | `dev`                      |
-| `LISTEN_ADDR`              | Address to bind the API server                                                         | `0.0.0.0:8000`             |
-| `API_KEY`                  | Bearer token used to authenticate requests                                             | _(none)_                   |
-| `INDEX_URL`                | Elasticsearch URL                                                                      | `http://localhost:9200`    |
-| `INDEX_AUTH_METHOD`        | Elasticsearch authentication (`none`, `basic`, `bearer`, `api_key`, `encoded_api_key`) | `none`                     |
-| `INDEX_CLIENT_ID`          | Elasticsearch client ID (required for `basic` or `api_key`)                            | _(none)_                   |
-| `INDEX_CLIENT_SECRET`      | Elasticsearch client secret (required for `basic`, `api_key` or `encoded_api_key`)     | _(none)_                   |
-| `INDEX_TLS_CA_CERT`        | Path to a PEM-encoded certificate chain to use for TLS validation                      | _(none)_                   |
-| `INDEX_TLS_SKIP_VERIFY`    | If `1`, do not validate the TLS certificate served by the Elasticsearch cluster        | `0`                        |
-| `INDEX_NAME`               | Index prefix under which data was indexed (suffixed by `-entities`)                    | `yente`                    |
-| `MANIFEST_URL`             | Optional URL to a custom manifest JSON file                                            | _(none)_                   |
-| `CATALOG_REFRESH_INTERVAL` | Interval at which to pull the manifest and catalogs                                    | _1h_                       |
-| `MATCH_CANDIDATES`         | Number of candidates to consider for matching                                          | `10`                       |
-| `ENABLE_PROMETHEUS`        | Enable Prometheus metrics collection and /metrics endpoint                             | `0`                        |
-| `ENABLE_TRACING`           | Set to `1` to enable tracing                                                           | _(none)_                   |
-| `TRACING_EXPORTER`         | Tracing exporter kind (`otlp`, or `gcp` if compiled with the `gcp` feature)            | `otlp`                     |
-| `REQUEST_TIMEOUT`          | Maximum duration for a match request                                                   | _10s_                      |
+| Variable                   | Description                                                                            | Default / Example         |
+| -------------------------- | -------------------------------------------------------------------------------------- | ------------------------- |
+| `ENV`                      | Environment (`dev` or `production`)                                                    | `dev`                     |
+| `LISTEN_ADDR`              | Address to bind the API server                                                         | `0.0.0.0:8000`            |
+| `API_KEY`                  | Bearer token used to authenticate requests                                             | _(none)_                  |
+| `INDEX_URL`                | Elasticsearch URL                                                                      | `http://localhost:9200`   |
+| `INDEX_AUTH_METHOD`        | Elasticsearch authentication (`none`, `basic`, `bearer`, `api_key`, `encoded_api_key`) | `none`                    |
+| `INDEX_CLIENT_ID`          | Elasticsearch client ID (required for `basic` or `api_key`)                            | _(none)_                  |
+| `INDEX_CLIENT_SECRET`      | Elasticsearch client secret (required for `basic`, `api_key` or `encoded_api_key`)     | _(none)_                  |
+| `INDEX_TLS_CA_CERT`        | Path to a PEM-encoded certificate chain to use for TLS validation                      | _(none)_                  |
+| `INDEX_TLS_SKIP_VERIFY`    | If `1`, do not validate the TLS certificate served by the Elasticsearch cluster        | `0`                       |
+| `INDEX_NAME`               | Index prefix under which data was indexed (suffixed by `-entities`)                    | `yente`                   |
+| `MANIFEST_URL`             | Optional URL to a custom manifest JSON file                                            | _(none)_                  |
+| `CATALOG_REFRESH_INTERVAL` | Interval at which to pull the manifest and catalogs                                    | _1h_                      |
+| `MATCH_CANDIDATES`         | Number of candidates to consider for matching                                          | `10`                      |
+| `ENRICHMENT_MAX_RECURSION` | Maximum recursion levels when enriching entities with relations                        | `2`                       |
+| `ENRICHMENT_QUERY_LIMIT`   | Maximum relation documents to fetch from Elasticsearch when building relation graphs   | `200`                     |
+| `ENABLE_PROMETHEUS`        | Enable Prometheus metrics collection and /metrics endpoint                             | `0`                       |
+| `ENABLE_TRACING`           | Set to `1` to enable tracing                                                           | _(none)_                  |
+| `TRACING_EXPORTER`         | Tracing exporter kind (`otlp`, or `gcp` if compiled with the `gcp` feature)            | `otlp`                    |
+| `REQUEST_TIMEOUT`          | Maximum duration for a match request                                                   | _10s_                     |
 | `SCOPED_INDEX_QUERY`       | Query used to scope down the index used for match queries                              | [see here](#scoped-index) |
 
 Setting `MANIFEST_FILE` is required if you use a customized dataset list and would like your own manifest to be used for catalog generation. If omitted, the default manifest provided by Yente will be used. It requires either an HTTP URL or a local file path ending in `.json`, `.yml` or `.yaml`.
@@ -80,12 +82,12 @@ Setting `MANIFEST_FILE` is required if you use a customized dataset list and wou
 
 Some unbounded-in-size query parameters can be passed in the request body instead of through the URL query. This prevents, for some of them taking in unbounded lists, to overflow the maximum length of URLs. Namely, you can now pass the following parameters in the body:
 
- * `include_dataset`
- * `exclude_dataset`
- * `exclude_entity_ids`
+- `include_dataset`
+- `exclude_dataset`
+- `exclude_entity_ids`
 
 The match endpoint body now takes a `params` object at its root:
- 
+
 ```json
 {
   "queries": [...],
@@ -120,7 +122,18 @@ The default scoped query is listed below, but can be customized through `SCOPED_
 {
   "bool": {
     "must": [
-      { "terms": { "schema": [ "Person", "LegalEntity", "Organization", "Company", "Airplane", "Vessel" ] } },
+      {
+        "terms": {
+          "schema": [
+            "Person",
+            "LegalEntity",
+            "Organization",
+            "Company",
+            "Airplane",
+            "Vessel"
+          ]
+        }
+      },
       { "term": { "topics": "sanction" } }
     ]
   }

--- a/crates/libmotiva/src/catalog.rs
+++ b/crates/libmotiva/src/catalog.rs
@@ -146,7 +146,7 @@ pub struct CatalogDatasetResource {
 pub struct CatalogDatasetPublisher {
   pub name: String,
   pub acronym: Option<String>,
-  pub url: String,
+  pub url: Option<String>,
   pub country: Option<String>,
   pub description: Option<String>,
   pub official: bool,

--- a/crates/libmotiva/src/index/elastic/queries.rs
+++ b/crates/libmotiva/src/index/elastic/queries.rs
@@ -161,9 +161,7 @@ impl IndexProvider for ElasticsearchProvider {
 
   /// Get entities related to an entity.
   #[instrument(skip_all)]
-  async fn get_related_entities(&self, root: Option<&String>, values: &[String], negatives: &HashSet<String, RandomState>) -> Result<Vec<Entity>, MotivaError> {
-    const RELATED_ENTITIES_LIMIT: i64 = 9999;
-
+  async fn get_related_entities(&self, root: Option<&String>, values: &[String], negatives: &HashSet<String, RandomState>, limit: usize) -> Result<Vec<Entity>, MotivaError> {
     let mut shoulds = vec![json!({ "ids": { "values": values } })];
 
     if let Some(root) = root {
@@ -174,15 +172,24 @@ impl IndexProvider for ElasticsearchProvider {
 
     let query = json!({
       "query": {
-          "bool": {
-              "should": shoulds,
-              "must_not": { "ids": { "values": negatives } },
-              "minimum_should_match": 1
-          },
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "should": shoulds,
+                "must_not": { "ids": { "values": negatives } },
+                "minimum_should_match": 1
+              },
+            }
+          ],
+          "should": [
+            { "term": { "schema": { "value": "Sanction", "boost": 1000 } } }
+          ]
+        }
       }
     });
 
-    let response = self.es.search(SearchParts::Index(&[&self.main_index])).from(0).size(RELATED_ENTITIES_LIMIT).body(query).send().await?;
+    let response = self.es.search(SearchParts::Index(&[&self.main_index])).from(0).size(limit as i64).body(query).send().await?;
 
     if response.status_code() != StatusCode::OK {
       let body: EsErrorResponse = response.json().await?;

--- a/crates/libmotiva/src/index/mock.rs
+++ b/crates/libmotiva/src/index/mock.rs
@@ -48,7 +48,7 @@ impl IndexProvider for MockedElasticsearch {
     unimplemented!();
   }
 
-  async fn get_related_entities(&self, root: Option<&String>, ids: &[String], negatives: &HashSet<String, RandomState>) -> Result<Vec<Entity>, MotivaError> {
+  async fn get_related_entities(&self, root: Option<&String>, ids: &[String], negatives: &HashSet<String, RandomState>, _limit: usize) -> Result<Vec<Entity>, MotivaError> {
     let negatives = HashSet::from_iter(negatives.iter().map(|id| id.to_owned()));
 
     for (args, entities) in &self.related_entitites {

--- a/crates/libmotiva/src/index/mod.rs
+++ b/crates/libmotiva/src/index/mod.rs
@@ -24,7 +24,7 @@ pub trait IndexProvider: Clone + Send + Sync + 'static {
   fn index_version(&self) -> IndexVersion;
   fn health(&self) -> impl Future<Output = Result<bool, MotivaError>> + Send;
   fn get_entity(&self, id: &str) -> impl Future<Output = Result<EntityHandle, MotivaError>> + Send;
-  fn get_related_entities(&self, root: Option<&String>, values: &[String], negatives: &HashSet<String, RandomState>) -> impl Future<Output = Result<Vec<Entity>, MotivaError>> + Send;
+  fn get_related_entities(&self, root: Option<&String>, values: &[String], negatives: &HashSet<String, RandomState>, limit: usize) -> impl Future<Output = Result<Vec<Entity>, MotivaError>> + Send;
   fn search(&self, catalog: &Arc<RwLock<Catalog>>, entity: &SearchEntity, params: &MatchParams) -> impl Future<Output = Result<Vec<Entity>, MotivaError>> + Send;
   fn list_indices(&self) -> impl Future<Output = Result<Vec<(String, String)>, MotivaError>> + Send;
 

--- a/crates/libmotiva/src/lib.rs
+++ b/crates/libmotiva/src/lib.rs
@@ -30,7 +30,7 @@ pub(crate) fn init() {
 pub mod prelude {
   pub use crate::catalog::{Catalog, CatalogDataset};
   pub use crate::fetcher::{CatalogFetcher, HttpCatalogFetcher};
-  pub use crate::motiva::{GetEntityBehavior, Motiva, MotivaConfig};
+  pub use crate::motiva::{GetEntityBehavior, GetEntityLimits, Motiva, MotivaConfig};
 
   pub use crate::error::MotivaError;
   pub use crate::index::{

--- a/crates/libmotiva/src/motiva.rs
+++ b/crates/libmotiva/src/motiva.rs
@@ -26,6 +26,30 @@ pub enum GetEntityBehavior {
   FetchNestedEntity,
 }
 
+/// Entity graph resolution effort settings
+#[derive(Clone, Copy)]
+pub struct GetEntityLimits {
+  /// How many levels of relations to walk when resolving nested entities
+  pub max_recursion: usize,
+  /// How many documents to fetch from Elasticsearch for each recursion level
+  pub query_limit: usize,
+}
+
+impl Default for GetEntityLimits {
+  fn default() -> Self {
+    Self { max_recursion: 2, query_limit: 200 }
+  }
+}
+
+impl GetEntityLimits {
+  pub fn new(recursion: usize, limit: usize) -> Self {
+    Self {
+      max_recursion: recursion,
+      query_limit: limit,
+    }
+  }
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct MotivaConfig {
   pub outdated_grace: Span,
@@ -166,7 +190,17 @@ impl<P: IndexProvider, F: CatalogFetcher> Motiva<P, F> {
   /// The `behavior` parameter defines whether to recurse into related entities
   /// to fetch their details. It returns an [`EntityHandle`], that can either be
   /// the entity, or the ID of another entity.
-  pub async fn get_entity(&self, id: &str, behavior: GetEntityBehavior) -> Result<EntityHandle, MotivaError> {
+  ///
+  /// When fetching nested entities, the level of "effort" put into resolving the
+  /// entity graph can be controlled through two knobs:
+  ///
+  ///  - The maximum recursion level to use when walking the graph
+  ///  - How many documents each recursion level will fetch from Elasticsearch
+  ///
+  /// `Sanction` related entities are prioritized to others and will be returned at
+  /// the top the results. The lower a relation comes up, the more likely it is to
+  /// be excluded from the results because it fell behind the query limit.
+  pub async fn get_entity(&self, id: &str, behavior: GetEntityBehavior, limits: GetEntityLimits) -> Result<EntityHandle, MotivaError> {
     match self.index.get_entity(id).await? {
       EntityHandle::Referent(id) => Ok(EntityHandle::Referent(id)),
 
@@ -175,7 +209,7 @@ impl<P: IndexProvider, F: CatalogFetcher> Motiva<P, F> {
           return Ok(EntityHandle::Nominal(entity));
         }
 
-        fetch_nested_entities(&self.index, &mut entity, id).await?;
+        fetch_nested_entities(&self.index, limits, &mut entity, id).await?;
 
         Ok(EntityHandle::Nominal(entity))
       }

--- a/crates/libmotiva/src/nested.rs
+++ b/crates/libmotiva/src/nested.rs
@@ -6,11 +6,9 @@ use std::{
 use ahash::{HashMap, RandomState};
 use itertools::Itertools;
 
-use crate::{Entity, IndexProvider, MotivaError, model::HasProperties, schemas::SCHEMAS};
+use crate::{Entity, IndexProvider, MotivaError, model::HasProperties, motiva::GetEntityLimits, schemas::SCHEMAS};
 
-const MAX_ITERATIONS: usize = 3;
-
-pub(crate) async fn fetch_nested_entities<P: IndexProvider>(index: &P, root_entity: &mut Entity, root_id: &str) -> Result<(), MotivaError> {
+pub(crate) async fn fetch_nested_entities<P: IndexProvider>(index: &P, limits: GetEntityLimits, root_entity: &mut Entity, root_id: &str) -> Result<(), MotivaError> {
   let mut all_entities: HashMap<String, Arc<Mutex<Entity>>> = HashMap::default();
   let mut seen = HashSet::<_, RandomState>::from_iter([root_id.to_string()]);
   let mut queue: HashSet<(String, String, String), RandomState> = HashSet::default();
@@ -27,7 +25,7 @@ pub(crate) async fn fetch_nested_entities<P: IndexProvider>(index: &P, root_enti
     }
   }
 
-  for iteration in 0..MAX_ITERATIONS {
+  for iteration in 0..limits.max_recursion {
     if queue.is_empty() && iteration > 0 {
       break;
     }
@@ -36,7 +34,7 @@ pub(crate) async fn fetch_nested_entities<P: IndexProvider>(index: &P, root_enti
     let root_id_string = root_id.to_string();
     let root = if iteration == 0 { Some(&root_id_string) } else { None };
 
-    let associations = index.get_related_entities(root, &to_fetch_ids, &seen).await?;
+    let associations = index.get_related_entities(root, &to_fetch_ids, &seen, limits.query_limit).await?;
 
     let mut next: HashSet<(String, String, String), RandomState> = HashSet::default();
 
@@ -149,14 +147,14 @@ fn queue_entity_references(association: &Entity, schema: &crate::schemas::FtmSch
 mod tests {
   use std_macro_extensions::{hash_set, string};
 
-  use crate::{Entity, MockedElasticsearch};
+  use crate::{Entity, MockedElasticsearch, motiva::GetEntityLimits};
 
   #[tokio::test]
   async fn no_references() {
     let mut root = Entity::builder("Person").id("person-1").build();
     let index = MockedElasticsearch::builder().build();
 
-    super::fetch_nested_entities(&index, &mut root, "person-1").await.unwrap();
+    super::fetch_nested_entities(&index, GetEntityLimits::default(), &mut root, "person-1").await.unwrap();
 
     assert!(root.properties.entities.is_empty());
   }
@@ -170,7 +168,7 @@ mod tests {
       .related_entitites(vec![((Some(string!("person-1")), vec![string!("wizard-1")], hash_set!(string!("person-1"))), vec![wizard.clone()])])
       .build();
 
-    super::fetch_nested_entities(&index, &mut root, "person-1").await.unwrap();
+    super::fetch_nested_entities(&index, GetEntityLimits::default(), &mut root, "person-1").await.unwrap();
 
     assert!(!root.properties.entities.contains_key("addressEntity"));
   }
@@ -184,7 +182,7 @@ mod tests {
       .related_entitites(vec![((Some(string!("person-1")), vec![string!("addr-1")], hash_set!(string!("person-1"))), vec![address.clone()])])
       .build();
 
-    super::fetch_nested_entities(&index, &mut root, "person-1").await.unwrap();
+    super::fetch_nested_entities(&index, GetEntityLimits::default(), &mut root, "person-1").await.unwrap();
 
     assert!(root.properties.entities.contains_key("addressEntity"));
 
@@ -206,7 +204,7 @@ mod tests {
       )])
       .build();
 
-    super::fetch_nested_entities(&index, &mut root, "person-1").await.unwrap();
+    super::fetch_nested_entities(&index, GetEntityLimits::default(), &mut root, "person-1").await.unwrap();
 
     assert!(root.properties.entities.contains_key("addressEntity"));
     let addresses = &root.properties.entities["addressEntity"];
@@ -230,7 +228,7 @@ mod tests {
       ])
       .build();
 
-    super::fetch_nested_entities(&index, &mut root, "person-1").await.unwrap();
+    super::fetch_nested_entities(&index, GetEntityLimits::default(), &mut root, "person-1").await.unwrap();
 
     assert!(root.properties.entities.contains_key("familyRelative"));
     let relatives = &root.properties.entities["familyRelative"];
@@ -260,7 +258,7 @@ mod tests {
       ])
       .build();
 
-    super::fetch_nested_entities(&index, &mut root, "person-1").await.unwrap();
+    super::fetch_nested_entities(&index, GetEntityLimits::default(), &mut root, "person-1").await.unwrap();
 
     assert!(root.properties.entities.contains_key("familyRelative"));
     let relatives = &root.properties.entities["familyRelative"];
@@ -285,7 +283,7 @@ mod tests {
       )])
       .build();
 
-    super::fetch_nested_entities(&index, &mut root, "company-1").await.unwrap();
+    super::fetch_nested_entities(&index, GetEntityLimits::default(), &mut root, "company-1").await.unwrap();
 
     assert!(root.properties.entities.contains_key("parent"));
     let parents = &root.properties.entities["parent"];
@@ -309,7 +307,7 @@ mod tests {
       ])
       .build();
 
-    super::fetch_nested_entities(&index, &mut root, "person-1").await.unwrap();
+    super::fetch_nested_entities(&index, GetEntityLimits::default(), &mut root, "person-1").await.unwrap();
 
     assert!(root.properties.entities.contains_key("proof"));
     let proof = &root.properties.entities["proof"];
@@ -329,7 +327,7 @@ mod tests {
       .related_entitites(vec![((Some(string!("person-1")), vec![string!("company-missing")], hash_set!(string!("person-1"))), vec![])])
       .build();
 
-    super::fetch_nested_entities(&index, &mut root, "person-1").await.unwrap();
+    super::fetch_nested_entities(&index, GetEntityLimits::default(), &mut root, "person-1").await.unwrap();
 
     assert!(root.properties.entities.is_empty());
   }
@@ -342,7 +340,7 @@ mod tests {
       .related_entitites(vec![((Some(string!("company-1")), vec![string!("company-1")], hash_set!(string!("company-1"))), vec![])])
       .build();
 
-    super::fetch_nested_entities(&index, &mut root, "company-1").await.unwrap();
+    super::fetch_nested_entities(&index, GetEntityLimits::default(), &mut root, "company-1").await.unwrap();
 
     assert!(!root.properties.entities.contains_key("parent"));
   }
@@ -364,7 +362,7 @@ mod tests {
       ])
       .build();
 
-    super::fetch_nested_entities(&index, &mut root, "person-1").await.unwrap();
+    super::fetch_nested_entities(&index, GetEntityLimits::default(), &mut root, "person-1").await.unwrap();
 
     let relatives = root.properties.entities.get("familyRelative").expect("root should have familyRelative entities");
 
@@ -392,7 +390,7 @@ mod tests {
       .related_entitites(vec![((Some(string!("person-1")), vec![string!("addr-1")], hash_set!(string!("person-1"))), vec![address.clone()])])
       .build();
 
-    super::fetch_nested_entities(&index, &mut root, "person-1").await.unwrap();
+    super::fetch_nested_entities(&index, GetEntityLimits::default(), &mut root, "person-1").await.unwrap();
 
     assert!(root.properties.entities.contains_key("addressEntity"));
     let addresses = &root.properties.entities["addressEntity"];

--- a/crates/motiva/src/api/config.rs
+++ b/crates/motiva/src/api/config.rs
@@ -7,7 +7,7 @@ use std::{
 
 use anyhow::Context;
 use jiff::Span;
-use libmotiva::{EsTlsVerification, prelude::EsAuthMethod};
+use libmotiva::{EsTlsVerification, GetEntityLimits, prelude::EsAuthMethod};
 use tokio::net::TcpListener;
 
 use crate::api::errors::AppError;
@@ -34,6 +34,10 @@ pub struct Config {
   pub outdated_grace: Span,
   pub match_candidates: usize,
 
+  // Enrichment settings
+  pub enrichment_max_recursion: usize,
+  pub enrichment_query_limit: usize,
+
   // Observability
   pub enable_prometheus: bool,
   pub enable_tracing: bool,
@@ -58,6 +62,8 @@ impl Config {
       index_auth_method: env::var("INDEX_AUTH_METHOD").unwrap_or("none".into()).parse::<WrappedEsAuthMethod>()?.0,
       index_tls_verification: parse_index_tls_verification()?,
       index_name: env::var("INDEX_NAME").ok(),
+      enrichment_max_recursion: parse_env("ENRICHMENT_MAX_RECURSION", GetEntityLimits::default().max_recursion)?,
+      enrichment_query_limit: parse_env("ENRICHMENT_QUERY_LIMIT", GetEntityLimits::default().query_limit)?,
       enable_prometheus: env::var("ENABLE_PROMETHEUS").unwrap_or_default() == "1",
       enable_tracing: env::var("ENABLE_TRACING").unwrap_or_default() == "1",
       tracing_exporter: env::var("TRACING_EXPORTER").unwrap_or("otlp".into()).parse()?,

--- a/crates/motiva/src/api/handlers/get_entity.rs
+++ b/crates/motiva/src/api/handlers/get_entity.rs
@@ -18,8 +18,9 @@ pub async fn get_entity<F: CatalogFetcher, P: IndexProvider>(
   Query(params): Query<GetEntityParams>,
 ) -> Result<impl IntoResponse, AppError> {
   let behavior = if params.nested { GetEntityBehavior::FetchNestedEntity } else { GetEntityBehavior::RootOnly };
+  let limit = GetEntityLimits::new(state.config.enrichment_max_recursion, state.config.enrichment_query_limit);
 
-  match state.motiva.get_entity(&id, behavior).await.map_err(Into::<AppError>::into)? {
+  match state.motiva.get_entity(&id, behavior, limit).await.map_err(Into::<AppError>::into)? {
     EntityHandle::Referent(id) => Ok(Redirect::permanent(&format!("/entities/{id}")).into_response()),
     EntityHandle::Nominal(entity) => Ok((StatusCode::OK, Json(entity)).into_response()),
   }

--- a/crates/motiva/src/tests/e2e/mod.rs
+++ b/crates/motiva/src/tests/e2e/mod.rs
@@ -25,6 +25,8 @@ async fn e2e() {
   let mut config = Config::default();
   config.listener = Some(listener);
   config.request_timeout = Span::from_str("10s").unwrap();
+  config.enrichment_max_recursion = 2;
+  config.enrichment_query_limit = 200;
 
   tokio::spawn(async move {
     run(config, provider).await.unwrap();

--- a/crates/motiva/tests/motiva.rs
+++ b/crates/motiva/tests/motiva.rs
@@ -44,5 +44,5 @@ async fn health() {
 // Should panic because mock function is not implemented.
 async fn get_entity() {
   let motiva = Motiva::test(MockedElasticsearch::default()).build().await.unwrap();
-  let _ = motiva.get_entity("", GetEntityBehavior::RootOnly).await;
+  let _ = motiva.get_entity("", GetEntityBehavior::RootOnly, GetEntityLimits::default()).await;
 }


### PR DESCRIPTION
Now, fetching nested relations from an entity will boost `Sanctions` to the top, making them more likely to be fetched if an entity has a lot of them.

Also, the two effort settings when fetching relations (query size and recursion level) can now be tweaked with settings. Higher numbers will provide better information, at the cost of performance.