### PR TITLE
Recursively resolve catalog relationships

### DIFF
--- a/crates/libmotiva/src/catalog.rs
+++ b/crates/libmotiva/src/catalog.rs
@@ -90,7 +90,7 @@ pub struct Catalog {
 }
 
 impl Catalog {
-  fn resolve_relationships(&mut self, loaded: Vec<CatalogDataset>) -> anyhow::Result<()> {
+  pub(crate) fn resolve_relationships(&mut self, loaded: Vec<CatalogDataset>) -> anyhow::Result<()> {
     for dataset in loaded {
       if dataset.children.is_empty() {
         continue;

--- a/crates/libmotiva/src/catalog.rs
+++ b/crates/libmotiva/src/catalog.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use itertools::Itertools;
 use jiff::{
@@ -89,6 +89,48 @@ pub struct Catalog {
   pub loaded_datasets: LoadedDatasets,
 }
 
+impl Catalog {
+  fn resolve_relationships(&mut self, loaded: Vec<CatalogDataset>) -> anyhow::Result<()> {
+    for dataset in loaded {
+      if dataset.children.is_empty() {
+        continue;
+      }
+
+      let mut acc = Vec::new();
+      let mut seen = HashSet::new();
+
+      self.recurse_resolve_relationship(&dataset.name, &mut acc, &mut seen)?;
+
+      if let Some(reference) = self.loaded_datasets.get_mut(&dataset.name) {
+        reference.datasets = acc;
+      }
+    }
+
+    Ok(())
+  }
+
+  fn recurse_resolve_relationship(&self, name: &str, acc: &mut Vec<String>, seen: &mut HashSet<String>) -> anyhow::Result<()> {
+    if !seen.insert(name.to_string()) {
+      return Ok(());
+    }
+
+    let Some(dataset) = self.loaded_datasets.get(name) else {
+      return Ok(());
+    };
+
+    match dataset.children.is_empty() {
+      true => acc.push(dataset.name.clone()),
+      false => {
+        for child in &dataset.children {
+          self.recurse_resolve_relationship(child, acc, seen)?;
+        }
+      }
+    }
+
+    Ok(())
+  }
+}
+
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct CatalogDataset {
   pub name: String,
@@ -124,6 +166,9 @@ pub struct CatalogDataset {
   pub last_change: Option<DateTime>,
   pub last_export: Option<DateTime>,
   pub updated_at: Option<DateTime>,
+
+  #[serde(skip)]
+  pub datasets: Vec<String>,
 
   // Motiva-specific metadata object
   #[serde(default)]
@@ -241,6 +286,11 @@ pub async fn get_merged_catalog<P: IndexProvider, F: CatalogFetcher>(fetcher: &F
 
   for ds in manifest.datasets {
     let mut dataset = CatalogDataset {
+      _type: if ds.datasets.as_ref().map(|d| !d.is_empty()).unwrap_or_default() {
+        Some("collection".into())
+      } else {
+        None
+      },
       name: ds.name.clone(),
       title: ds.title,
       load: true,
@@ -261,6 +311,7 @@ pub async fn get_merged_catalog<P: IndexProvider, F: CatalogFetcher>(fetcher: &F
 
   catalog.index_stale = !catalog.outdated.is_empty();
   catalog.loaded_datasets = catalog.datasets.iter().map(|dataset| (dataset.name.clone(), dataset.clone())).collect::<HashMap<_, _>>();
+  catalog.resolve_relationships(catalog.datasets.clone())?;
 
   tracing::info!(datasets = catalog.datasets.len(), "fetched catalog");
 
@@ -338,5 +389,53 @@ mod tests {
     assert!(!datasets_by_name["dataset3"].load);
     assert!(datasets_by_name["dataset3"].index_version.is_none());
     assert!(!datasets_by_name["dataset3"].index_current);
+  }
+
+  #[test]
+  fn resolve_dataset_relationships() {
+    fn dataset(name: &str, children: &[&str]) -> CatalogDataset {
+      CatalogDataset {
+        name: name.to_string(),
+        children: children.iter().map(|c| c.to_string()).collect(),
+        ..Default::default()
+      }
+    }
+
+    fn resolve(datasets: Vec<CatalogDataset>) -> Catalog {
+      let mut catalog = Catalog {
+        loaded_datasets: datasets.iter().map(|d| (d.name.clone(), d.clone())).collect(),
+        ..Default::default()
+      };
+
+      catalog.resolve_relationships(datasets).unwrap();
+      catalog
+    }
+
+    // Regular run
+    let catalog = resolve(vec![dataset("a", &["b", "c"]), dataset("c", &["d"]), dataset("b", &[]), dataset("d", &[])]);
+
+    assert_eq!(catalog.loaded_datasets["a"].datasets, vec!["b".to_string(), "d".to_string()]);
+
+    // Diamond relationships
+    let catalog = resolve(vec![dataset("a", &["b", "c"]), dataset("b", &["d"]), dataset("c", &["d"]), dataset("d", &[])]);
+
+    assert_eq!(catalog.loaded_datasets["a"].datasets, vec!["d".to_string()]);
+
+    // Missing children
+    let catalog = resolve(vec![dataset("a", &["b", "missing"]), dataset("b", &[])]);
+
+    assert_eq!(catalog.loaded_datasets["a"].datasets, vec!["b".to_string()]);
+
+    // Cycle-free
+    let catalog = resolve(vec![dataset("a", &["b"]), dataset("b", &["a"])]);
+
+    assert!(catalog.loaded_datasets["a"].datasets.is_empty());
+    assert!(catalog.loaded_datasets["b"].datasets.is_empty());
+
+    // Partial cycle is all good
+    let catalog = resolve(vec![dataset("a", &["b", "c"]), dataset("b", &["a"]), dataset("c", &[])]);
+
+    assert_eq!(catalog.loaded_datasets["a"].datasets, vec!["c".to_string()]);
+    assert_eq!(catalog.loaded_datasets["b"].datasets, vec!["c".to_string()]);
   }
 }

--- a/crates/libmotiva/src/fetcher.rs
+++ b/crates/libmotiva/src/fetcher.rs
@@ -220,7 +220,7 @@ mod tests {
   async fn valid_local_file_yaml() {
     for ext in ["yml", "yaml"] {
       std::fs::write(
-        &format!("/tmp/motiva-manifest.{ext}"),
+        format!("/tmp/motiva-manifest.{ext}"),
         r#"
       catalogs:
         - url: http://myurl.tld

--- a/crates/libmotiva/src/index/elastic/queries.rs
+++ b/crates/libmotiva/src/index/elastic/queries.rs
@@ -562,34 +562,35 @@ mod tests {
     Arc::new(RwLock::new({
       let mut catalog = Catalog::default();
 
-      catalog.loaded_datasets.insert(
-        "myscope".to_string(),
+      catalog.datasets = vec![
         CatalogDataset {
-          name: "Real Dataset".to_string(),
+          name: "myscope".to_string(),
           children: vec!["realdataset".to_string()],
           _type: Some("collection".to_string()),
           ..Default::default()
         },
-      );
-
-      catalog.loaded_datasets.insert(
-        "otherscope".to_string(),
         CatalogDataset {
-          name: "Other Dataset".to_string(),
+          name: "realdataset".to_string(),
+          ..Default::default()
+        },
+        CatalogDataset {
+          name: "otherscope".to_string(),
           children: vec!["otherdataset".to_string()],
           _type: Some("collection".to_string()),
           ..Default::default()
         },
-      );
-
-      catalog.loaded_datasets.insert(
-        "baredataset".to_string(),
+        CatalogDataset {
+          name: "otherdataset".to_string(),
+          ..Default::default()
+        },
         CatalogDataset {
           name: "baredataset".to_string(),
           ..Default::default()
         },
-      );
+      ];
 
+      catalog.loaded_datasets = catalog.datasets.iter().map(|dataset| (dataset.name.clone(), dataset.clone())).collect::<HashMap<_, _>>();
+      catalog.resolve_relationships(catalog.datasets.clone()).unwrap();
       catalog
     }))
   }

--- a/crates/libmotiva/src/index/elastic/queries.rs
+++ b/crates/libmotiva/src/index/elastic/queries.rs
@@ -337,7 +337,7 @@ async fn build_datasets(catalog: &Arc<RwLock<Catalog>>, filters: &mut Vec<serde_
       .loaded_datasets
       .get(&params.scope)
       .map(|dataset| match dataset._type.as_deref() {
-        Some("collection") => dataset.children.clone(),
+        Some("collection") => dataset.datasets.clone(),
         _ => vec![dataset.name.clone()],
       })
       .unwrap_or_default()

--- a/crates/libmotiva/src/matching/extractors.rs
+++ b/crates/libmotiva/src/matching/extractors.rs
@@ -280,7 +280,7 @@ mod tests {
     let inputs: Vec<(&str, Vec<&str>)> = vec![("ben'laden,ossama", vec!["benladen", "ossama"]), ("Ser. Bobby O'Brian", vec!["Ser", "Bobby", "OBrian"])];
 
     for (input, expected) in inputs {
-      let names = super::tokenize_names(vec![input].iter()).flatten().collect::<Vec<_>>();
+      let names = super::tokenize_names([input].iter()).flatten().collect::<Vec<_>>();
 
       assert_eq!(&names, &expected);
     }
@@ -304,22 +304,22 @@ mod tests {
 
   #[test]
   fn clean_names() {
-    assert_eq!(super::clean_names(vec!["Bob-a O'Brien#2nd"].iter()).collect::<Vec<_>>(), vec!["bob a obrien 2nd"]);
-    assert_eq!(super::clean_names(vec!["Владимир Владимирович Путин"].iter()).collect::<Vec<_>>(), vec!["vladimir vladimirovich putin"]);
+    assert_eq!(super::clean_names(["Bob-a O'Brien#2nd"].iter()).collect::<Vec<_>>(), vec!["bob a obrien 2nd"]);
+    assert_eq!(super::clean_names(["Владимир Владимирович Путин"].iter()).collect::<Vec<_>>(), vec!["vladimir vladimirovich putin"]);
   }
 
   #[test]
   fn clean_names_light() {
-    assert_eq!(super::clean_names_light(vec!["Vladimir Putin Jr."].iter()).collect::<Vec<_>>(), vec!["vladimir putin jr"]);
+    assert_eq!(super::clean_names_light(["Vladimir Putin Jr."].iter()).collect::<Vec<_>>(), vec!["vladimir putin jr"]);
     assert_eq!(
-      super::clean_names_light(vec!["Владимир Владимирович Путин"].iter()).collect::<Vec<_>>(),
+      super::clean_names_light(["Владимир Владимирович Путин"].iter()).collect::<Vec<_>>(),
       vec!["владимир владимирович путин"]
     );
   }
 
   #[test]
   fn normalize_identifiers() {
-    assert_eq!(super::normalize_identifiers(vec!["FR12-34/uc12.3 (d)"].iter()).collect::<Vec<_>>(), vec!["FR1234UC123D"]);
+    assert_eq!(super::normalize_identifiers(["FR12-34/uc12.3 (d)"].iter()).collect::<Vec<_>>(), vec!["FR1234UC123D"]);
   }
 
   #[test]

--- a/crates/libmotiva/src/model.rs
+++ b/crates/libmotiva/src/model.rs
@@ -114,6 +114,12 @@ impl Schema {
   }
 }
 
+#[derive(Clone, Debug)]
+pub struct PayloadParams {
+  pub include_datasets: Option<Vec<String>>,
+  pub exclude_datasets: Option<Vec<String>>,
+}
+
 /// Search terms
 #[derive(Clone, Debug, Deserialize, Serialize, Validate)]
 pub struct SearchEntity {
@@ -123,6 +129,8 @@ pub struct SearchEntity {
 
   #[serde(default)]
   pub filters: Option<HashMap<String, Vec<Vec<String>>>>,
+  #[serde(skip)]
+  pub params: Option<PayloadParams>,
 
   // Those attributes will be precomputed when receiving the request to skip the computation for every matching entity.
   #[serde(skip)]
@@ -300,6 +308,7 @@ impl SearchEntity {
       schema: Schema::from(schema),
       properties: props,
       filters: None,
+      params: None,
       clean_names: Default::default(),
       name_parts: Default::default(),
       name_parts_flat: Default::default(),

--- a/crates/libmotiva/src/model.rs
+++ b/crates/libmotiva/src/model.rs
@@ -571,7 +571,7 @@ mod tests {
     se.precompute();
 
     assert_eq!(
-      HashSet::from_iter(se.properties.get("citizenship").unwrap().into_iter().cloned()),
+      HashSet::from_iter(se.properties.get("citizenship").unwrap().iter().cloned()),
       HashSet::from_iter(["ru", "fr", "gb"].into_iter().map(str::to_string)),
     );
   }

--- a/crates/libmotiva/src/tests/python.rs
+++ b/crates/libmotiva/src/tests/python.rs
@@ -95,7 +95,7 @@ pub(crate) fn nomenklatura_comparer(path: &str, function: &str, query: &SearchEn
     };
 
     let inspect = py.import("inspect")?.getattr("signature")?;
-    let matcher = py.import(&format!("nomenklatura.matching.{path}"))?.getattr(function)?;
+    let matcher = py.import(format!("nomenklatura.matching.{path}"))?.getattr(function)?;
 
     let score: f64 = match inspect.call1((matcher.clone(),))?.getattr("parameters")?.len()? {
       2 => matcher.call1((&query, entity))?.extract()?,
@@ -116,7 +116,7 @@ pub(crate) fn nomenklatura_comparer(path: &str, function: &str, query: &SearchEn
 
 pub(crate) fn nomenklatura_str_list(path: &str, function: &str, query: &[&str], entity: &[&str]) -> anyhow::Result<f64> {
   let result = Python::attach::<_, PyResult<f64>>(|py| {
-    let matcher = py.import(&format!("nomenklatura.matching.{path}"))?.getattr(function)?;
+    let matcher = py.import(format!("nomenklatura.matching.{path}"))?.getattr(function)?;
     let score = matcher.call1((query, entity))?.extract()?;
 
     Ok(score)

--- a/crates/motiva/src/api/config.rs
+++ b/crates/motiva/src/api/config.rs
@@ -213,7 +213,7 @@ mod tests {
     assert_eq!(config.match_candidates, 3);
     assert_eq!(config.index_url, "http://index");
     assert_eq!(config.index_auth_method, EsAuthMethod::EncodedApiKey("secret".to_string()));
-    assert_eq!(config.enable_tracing, true);
+    assert!(config.enable_tracing);
 
     unsafe {
       env::remove_var("ENV");
@@ -235,14 +235,14 @@ mod tests {
       env::set_var("INDEX_CLIENT_SECRET", "secret");
     }
 
-    assert!(matches!(Config::from_env().await, Err(_)));
+    assert!(Config::from_env().await.is_err());
 
     unsafe {
       env::set_var("INDEX_AUTH_METHOD", "api_key");
       env::set_var("INDEX_CLIENT_SECRET", "secret");
     }
 
-    assert!(matches!(Config::from_env().await, Err(_)));
+    assert!(Config::from_env().await.is_err());
 
     unsafe {
       env::set_var("INDEX_AUTH_METHOD", "basic");
@@ -281,10 +281,10 @@ mod tests {
     }
 
     assert_eq!(super::parse_env::<u32>("INT", 0).unwrap(), 42);
-    assert_eq!(super::parse_env::<bool>("BOOL", true).unwrap(), true);
+    assert!(super::parse_env::<bool>("BOOL", true).unwrap());
     assert_eq!(super::parse_env::<IpAddr>("IP", IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))).unwrap(), IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)));
 
-    assert!(matches!(super::parse_env::<u32>("BOOL", 0), Err(_)));
+    assert!(super::parse_env::<u32>("BOOL", 0).is_err());
 
     unsafe {
       env::remove_var("INT");
@@ -296,7 +296,7 @@ mod tests {
   #[test]
   fn es_auth_method_from_str() {
     assert!(matches!("otlp".parse(), Ok(TracingExporter::Otlp)));
-    assert!(matches!("other".parse::<TracingExporter>(), Err(_)));
+    assert!("other".parse::<TracingExporter>().is_err());
   }
 
   #[test]
@@ -313,7 +313,7 @@ mod tests {
     assert!(matches!("api_key".parse::<WrappedEsAuthMethod>(), Ok(WrappedEsAuthMethod(EsAuthMethod::ApiKey(_, _)))));
     assert!(matches!("encoded_api_key".parse::<WrappedEsAuthMethod>(), Ok(WrappedEsAuthMethod(EsAuthMethod::EncodedApiKey(_)))));
 
-    assert!(matches!("other".parse::<WrappedEsAuthMethod>(), Err(_)));
+    assert!("other".parse::<WrappedEsAuthMethod>().is_err());
 
     unsafe {
       env::remove_var("INDEX_CLIENT_ID");

--- a/crates/motiva/src/api/dto.rs
+++ b/crates/motiva/src/api/dto.rs
@@ -13,17 +13,17 @@ pub struct GetEntityParams {
   pub nested: bool,
 }
 
-#[derive(Clone, Debug, Deserialize, Validate)]
+#[derive(Clone, Debug, Deserialize, Serialize, Validate)]
 pub(crate) struct Payload {
   #[validate(nested, length(min = 1, message = "at least one query must be provided"))]
   pub queries: HashMap<String, SearchEntity, RandomState>,
 
   // Some query parameters are duplicated in the request body to overcome URL size limitations
-  #[serde(default)]
+  #[serde(skip)]
   pub params: PayloadParams,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
 pub(crate) struct PayloadParams {
   #[serde(default)]
   pub include_datasets: Option<Vec<String>>,

--- a/crates/motiva/src/api/handlers/match_entities.rs
+++ b/crates/motiva/src/api/handlers/match_entities.rs
@@ -44,12 +44,21 @@ pub async fn match_entities<F: CatalogFetcher, P: IndexProvider + 'static>(
   });
 
   let state = Arc::new(state);
-  let query = Arc::new(query);
 
   let tasks = body.queries.into_iter().map(|(id, entity)| {
+    let mut query = query.clone();
+
+    if let Some(ref params) = entity.params {
+      if let Some(ref datasets) = params.include_datasets {
+        query.include_dataset = datasets.clone();
+      }
+      if let Some(ref datasets) = params.exclude_datasets {
+        query.exclude_dataset = datasets.clone();
+      }
+    }
+
     tokio::spawn({
       let state = Arc::clone(&state);
-      let query = Arc::clone(&query);
 
       async move {
         let hits = match state.motiva.search(&entity, &query).await {

--- a/crates/motiva/src/tests/e2e/mod.rs
+++ b/crates/motiva/src/tests/e2e/mod.rs
@@ -15,18 +15,20 @@ use crate::{api::config::Config, run};
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "end-to-end tests can only be run manually"]
 async fn e2e() {
-  let provider = ElasticsearchProvider::new(option_env!("INDEX_URL").unwrap_or_else(|| "http://localhost:9200".into()), EsOptions::default())
+  let provider = ElasticsearchProvider::new(option_env!("INDEX_URL").unwrap_or_else(|| "http://localhost:9200"), EsOptions::default())
     .await
     .unwrap();
 
   let listener = TcpListener::bind("0.0.0.0:0").await.unwrap();
   let addr = listener.local_addr().unwrap();
 
-  let mut config = Config::default();
-  config.listener = Some(listener);
-  config.request_timeout = Span::from_str("10s").unwrap();
-  config.enrichment_max_recursion = 2;
-  config.enrichment_query_limit = 200;
+  let config = Config {
+    listener: Some(listener),
+    request_timeout: Span::from_str("10s").unwrap(),
+    enrichment_max_recursion: 2,
+    enrichment_query_limit: 200,
+    ..Default::default()
+  };
 
   tokio::spawn(async move {
     run(config, provider).await.unwrap();

--- a/crates/motiva/src/tests/log_writer.rs
+++ b/crates/motiva/src/tests/log_writer.rs
@@ -26,6 +26,7 @@ impl VecLogWriter {
 }
 
 impl io::Write for VecLogWriter {
+  #[allow(clippy::print_stdout)]
   fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
     let mut buffer = self.buffer.lock().unwrap();
 

--- a/crates/motiva/src/tests/middlewares.rs
+++ b/crates/motiva/src/tests/middlewares.rs
@@ -102,7 +102,7 @@ rusty_fork_test! {
 
             signal::kill(Pid::from_raw(std::process::id() as i32), Some(signal::Signal::SIGINT)).unwrap();
 
-            assert!(matches!(reqwest::get("http://localhost:8080/healthz").await, Err(_)));
+            assert!(reqwest::get("http://localhost:8080/healthz").await.is_err());
         });
     }
 

--- a/crates/motiva/tests/motiva.rs
+++ b/crates/motiva/tests/motiva.rs
@@ -36,7 +36,7 @@ async fn health() {
 
   let motiva = Motiva::test(MockedElasticsearch::default()).build().await.unwrap();
 
-  assert!(matches!(motiva.health().await, Err(_)));
+  assert!(motiva.health().await.is_err());
 }
 
 #[tokio::test]


### PR DESCRIPTION
The way datasets were resolved from the catalog and the provided scope was very naive and needed to evolve to allow for custom collections containing both datasets and other collections.

We now recurively traverse all relationships on startup to quickly match datasets to requested scopes during queries. 