### PR TITLE
Add index filter and skip name combinations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,10 @@ RUN cargo build --release --bin motiva ${CARGO_ARGS}
 
 FROM gcr.io/distroless/cc:latest
 
+LABEL org.opencontainers.image.source="https://github.com/apognu/motiva"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.description="Sanctions screening tool"
+
 COPY --from=builder /app/target/release/motiva /motiva
 # Fallible step, will only copy libicu files if they exist
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libicu* /usr/lib/x86_64-linux-gnu/

--- a/crates/libmotiva/README.md
+++ b/crates/libmotiva/README.md
@@ -78,6 +78,12 @@ Setting `MANIFEST_FILE` is required if you use a customized dataset list and wou
 
 ## Motiva-specific features
 
+### Scope-partitioned queries
+
+In those cases where the requested scope exactly matches an indexed scope, you can pass `?partition=true` to your query to add a filter on that particular index prefix instead of only using a post-scan datasets filter. This has the potential to greatly increase performance when the data distribution between your indexes is highly imbalanced.
+
+**Note:** this would not work if your query scope does not match your indexed scope. For example, if you index part of the data (with `"scope": "us_sanctions"` for example), but still query it with `/match/default`, no results would ever be returned where it would have without partitioning.
+
 ### Query options passed in body
 
 Some unbounded-in-size query parameters can be passed in the request body instead of through the URL query. This prevents, for some of them taking in unbounded lists, to overflow the maximum length of URLs. Namely, you can now pass the following parameters in the body:

--- a/crates/libmotiva/src/index/elastic/queries.rs
+++ b/crates/libmotiva/src/index/elastic/queries.rs
@@ -68,7 +68,7 @@ impl IndexProvider for ElasticsearchProvider {
   /// Search for candidate entities matching input parameters.
   #[instrument(skip_all)]
   async fn search(&self, catalog: &Arc<RwLock<Catalog>>, entity: &SearchEntity, params: &MatchParams) -> Result<Vec<Entity>, MotivaError> {
-    let query = build_query(catalog, self.index_version, entity, params).await?;
+    let query = build_query(catalog, self.index_version, self.index_name(params.index_type), entity, params).await?;
 
     tracing::trace!(%query, "running query");
 
@@ -220,7 +220,7 @@ impl IndexProvider for ElasticsearchProvider {
   async fn list_indices(&self) -> Result<Vec<(String, String)>, MotivaError> {
     let indices: HashMap<String, serde_json::Value> = self.es.indices().get_alias(IndicesGetAliasParts::Name(&[&self.main_index])).send().await?.json().await?;
 
-    Ok(parse_index_dataset_versions(indices))
+    Ok(parse_index_dataset_versions(&self.main_index, indices))
   }
 
   async fn list_field_values(&self, fields: &[&str], query: Option<serde_json::Value>) -> Result<HashMap<String, Vec<String>>, MotivaError> {
@@ -259,12 +259,12 @@ impl IndexProvider for ElasticsearchProvider {
   }
 }
 
-fn parse_index_dataset_versions(indices: HashMap<String, serde_json::Value>) -> Vec<(String, String)> {
+fn parse_index_dataset_versions(index_name: &str, indices: HashMap<String, serde_json::Value>) -> Vec<(String, String)> {
   indices
     .keys()
     .cloned()
     .filter_map(|name| {
-      if let Some(stripped) = name.strip_prefix("yente-entities-") {
+      if let Some(stripped) = name.strip_prefix(&format!("{index_name}-")) {
         let mut stripped = stripped.split("-");
 
         match (stripped.next(), stripped.skip(1).join("-")) {
@@ -278,17 +278,26 @@ fn parse_index_dataset_versions(indices: HashMap<String, serde_json::Value>) -> 
     .collect::<Vec<_>>()
 }
 
-async fn build_query(catalog: &Arc<RwLock<Catalog>>, index_version: IndexVersion, entity: &SearchEntity, params: &MatchParams) -> Result<serde_json::Value, MotivaError> {
+async fn build_query(catalog: &Arc<RwLock<Catalog>>, index_version: IndexVersion, index_name: &str, entity: &SearchEntity, params: &MatchParams) -> Result<serde_json::Value, MotivaError> {
   Ok(json!({
       "query": {
           "bool": {
               "filter": build_filters(catalog, entity, params).await?,
+              "must": build_musts(index_name, params),
               "should": build_shoulds(index_version, entity, params.name_sample_size)?,
               "must_not": build_must_nots(params),
               "minimum_should_match": 1,
           }
       }
   }))
+}
+
+fn build_musts(index_name: &str, params: &MatchParams) -> Vec<serde_json::Value> {
+  if params.partition {
+    vec![json!({ "prefix": { "_index": format!("{}-{}-", index_name, params.scope) } })]
+  } else {
+    Default::default()
+  }
 }
 
 async fn build_filters(catalog: &Arc<RwLock<Catalog>>, entity: &SearchEntity, params: &MatchParams) -> Result<Vec<serde_json::Value>, MotivaError> {
@@ -641,7 +650,7 @@ mod tests {
       ])
       .build();
 
-    super::build_query(&fake_catalog(), IndexVersion::V4, &entity, &MatchParams::default()).await.unwrap();
+    super::build_query(&fake_catalog(), IndexVersion::V4, "yente-entities", &entity, &MatchParams::default()).await.unwrap();
   }
 
   #[test]
@@ -899,7 +908,7 @@ mod tests {
       .map(|(n, v)| (format!("yente-entities-{n}-any-{v}"), json!({})))
       .collect::<HashMap<String, _>>();
 
-    let versions = super::parse_index_dataset_versions(input);
+    let versions = super::parse_index_dataset_versions("yente-entities", input);
 
     assert_eq!(versions.len(), 2);
     assert_eq!(

--- a/crates/libmotiva/src/matching/mod.rs
+++ b/crates/libmotiva/src/matching/mod.rs
@@ -140,6 +140,8 @@ pub struct MatchParams {
 
   // Motiva-specific params
   #[serde(default)]
+  pub partition: bool,
+  #[serde(default)]
   pub index_type: IndexType,
   #[serde(default)]
   pub match_candidates: usize,

--- a/crates/libmotiva/src/model.rs
+++ b/crates/libmotiva/src/model.rs
@@ -166,6 +166,10 @@ impl SearchEntity {
   }
 
   pub fn combine_names(&mut self) {
+    if self.prop_group("name", PropertyFilter::Matchable).len() > 20 {
+      return;
+    }
+
     let aliases = {
       let firstnames = self.props(&["firstName"]);
       let secondnames = self.props(&["secondName"]);

--- a/crates/motiva/src/tests/e2e/specs/match.hurl
+++ b/crates/motiva/src/tests/e2e/specs/match.hurl
@@ -85,3 +85,45 @@ HTTP 200
 jsonpath "$.responses.test.status" == 200
 jsonpath "$.responses.test.results[?(@.id == 'Q7747')].caption" contains "Vladimir Vladimirovich Putin"
 jsonpath "$.responses.test.results[?(@.id == 'Q7747')].score" == 1.0
+
+# Match query with scope partition and wrong scope
+
+POST http://{{baseUrl}}/match/default?partition=true
+{
+    "queries": {
+        "test": {
+            "schema": "Person",
+            "properties": {
+                "name": ["Vladimir Putin"]
+            }
+        }
+    }
+}
+
+HTTP 200
+
+[Asserts]
+jsonpath "$.responses.test.status" == 200
+jsonpath "$.responses.test.results" count == 0
+
+# Match query with scope partition and right scope
+
+POST http://{{baseUrl}}/match/us_sanctions?partition=true
+{
+    "queries": {
+        "test": {
+            "schema": "Person",
+            "properties": {
+                "name": ["Vladimir Putin"]
+            }
+        }
+    }
+}
+
+HTTP 200
+
+[Asserts]
+jsonpath "$.responses.test.status" == 200
+jsonpath "$.responses.test.results" count == 1
+jsonpath "$.responses.test.results[?(@.id == 'Q7747')].caption" contains "Vladimir Vladimirovich Putin"
+jsonpath "$.responses.test.results[?(@.id == 'Q7747')].score" == 1.0


### PR DESCRIPTION
This is a performance commit:

 - A query's scope was only used to determine the dataset filter, but it still only targeted the overall alias, meaning performance was left on the table while other member indices were scanned, even though they would never yield any result. Now, we add an `_index` prefix filter to the query, which Elasticsearch is able to optimize to skip non-matching indices entirely.
   This is opt-in, through `?partition=true`, because otherwise it would break requests where the query scope is different from the indexed one (indexed `us_sanctions` could not be queried with `/match/default` anymore).
 - We used to always create new names by combining name parts (first, second, middle, mother, father, last), which is useful for search entities that don't provide a lot of information. Yet, when full entities are used for search, the combinatorial explosion can get unwieldy (we found a case where 105k synthetic names were built, adding significantly to the latency, before even hitting Elasticsearch. This PR skips the name combination function if we already have more than 20 name-like properties.

---

The performance issue still occurs if we happen to use a search entity where:

 - There are less than 20 full name-like properties
 - There is an absurd number of name parts

We might improve this by arbitrarily truncate the list of name parts to X each. This would result in a partial query (which arguably is already the case because we only keep the 10 "best" names for the query), but let's see how this one perform first.