### PR TITLE
Marble V0: new algorithm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "alcs"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f411ec469f16177489d7427a803ed485c87110a8aa88e026545ffcd2ee882447"
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2424,6 +2430,7 @@ version = "0.3.0"
 dependencies = [
  "ahash",
  "aho-corasick",
+ "alcs",
  "any_ascii",
  "anyhow",
  "bon",

--- a/crates/libmotiva/Cargo.toml
+++ b/crates/libmotiva/Cargo.toml
@@ -18,6 +18,7 @@ benchmarks = []
 [dependencies]
 ahash = { version = "0.8.12", features = ["serde"] }
 aho-corasick = "1.1.3"
+alcs = "0.1.3"
 any_ascii = "0.3.3"
 anyhow = "1.0.98"
 bon = { version = "3.6.5" }

--- a/crates/libmotiva/src/lib.rs
+++ b/crates/libmotiva/src/lib.rs
@@ -37,7 +37,7 @@ pub mod prelude {
     EntityHandle, IndexProvider,
     elastic::{ElasticsearchProvider, builder::EsAuthMethod, builder::EsTlsVerification, config::EsOptions, scoped::create_scoped_index},
   };
-  pub use crate::matching::{Algorithm, Feature, MatchParams, MatchingAlgorithm, logic_v1::LogicV1, name_based::NameBased, name_qualified::NameQualified};
+  pub use crate::matching::{Algorithm, Feature, MatchParams, MatchingAlgorithm, logic_v1::LogicV1, marble_v0::MarbleV0, name_based::NameBased, name_qualified::NameQualified};
   pub use crate::model::{Entity, HasProperties, SearchEntity};
 }
 

--- a/crates/libmotiva/src/matching/logic_v1.rs
+++ b/crates/libmotiva/src/matching/logic_v1.rs
@@ -47,18 +47,19 @@ static FEATURES: LazyLock<Vec<(&'static dyn Feature, f64)>> = LazyLock::new(|| {
     (IdentifierMatch::new("vessel_imo_mmsi_match", &["imoNumber", "mmsi"], Some(validate_imo_mmsi)), 0.95),
     (IdentifierMatch::new("inn_code_match", &["innCode"], Some(validate_inn)), 0.95),
     (IdentifierMatch::new("bic_code_match", &["bicCode"], Some(validate_bic)), 0.95),
-    (SimpleMatch::new("identifier_match", &|e| e.prop_group("identifier", PropertyFilter::All), None), 0.85), // TODO: add cleaning
+    (SimpleMatch::new("identifier_match", &|e| e.prop_group("identifier", PropertyFilter::Matchable), None), 0.85), // TODO: add cleaning
     (&WeakAliasMatch, 0.8),
   ]
 });
 
 static QUALIFIERS: LazyLock<Vec<(&'static dyn Feature, f64)>> = LazyLock::new(|| {
   vec![
-    (SimpleMismatch::new("country_mismatch", &|e| e.prop_group("country", PropertyFilter::All), None), -0.2),
+    (SimpleMismatch::new("country_mismatch", &|e| e.prop_group("country", PropertyFilter::Matchable), None), -0.2),
     (SimpleMismatch::new("last_name_mismatch", &|e| e.props(&["lastName"]), None), -0.2),
     (SimpleMismatch::new("dob_year_disjoint", &|e| e.props(&["birthDate"]), Some(dob_year_disjoint)), -0.15),
     (SimpleMismatch::new("dob_day_disjoint", &|e| e.props(&["birthDate"]), Some(dob_day_disjoint)), -0.2),
     (SimpleMismatch::new("gender_mismatch", &|e| e.props(&["gender"]), None), -0.2),
+    (SimpleMismatch::new("identifier_mismatch", &|e| e.prop_group("identifier", PropertyFilter::Matchable), None), 0.0), // Motiva-specific, disabled by default
     (&OrgIdMismatch, -0.2),
     (&NumbersMismatch, -0.1),
   ]

--- a/crates/libmotiva/src/matching/logic_v1.rs
+++ b/crates/libmotiva/src/matching/logic_v1.rs
@@ -64,6 +64,44 @@ static QUALIFIERS: LazyLock<Vec<(&'static dyn Feature, f64)>> = LazyLock::new(||
   ]
 });
 
+pub(crate) fn logic_v1(
+  bump: &Bump,
+  lhs: &crate::model::SearchEntity,
+  rhs: &crate::model::Entity,
+  cutoff: f64,
+  features: &[(&'static dyn Feature, f64)],
+  qualifiers: &[(&'static dyn Feature, f64)],
+  disqualifiers: &[(&'static dyn Feature, f64)],
+) -> (f64, Vec<(&'static str, f64)>) {
+  if !rhs.schema.can_match(lhs.schema.as_str()) {
+    return (0.0, vec![]);
+  }
+
+  let mut results = Vec::with_capacity(features.len() + qualifiers.len() + disqualifiers.len());
+  let mut score = 0.0f64;
+
+  for (func, weight) in features.iter() {
+    let span = info_span!("scoring_feature", feature = func.name());
+    let _span = span.enter();
+
+    let then = Instant::now();
+    let feature_score = func.score_feature(bump, lhs, rhs);
+
+    results.push((func.name(), feature_score));
+
+    if (feature_score * weight) > score {
+      score = feature_score * weight;
+    }
+
+    tracing::debug!(feature = func.name(), score = feature_score, latency = ?then.elapsed(), "computed feature score");
+  }
+
+  let score = run_features(bump, lhs, rhs, cutoff, score, qualifiers.iter(), &mut results);
+  let score = run_features(bump, lhs, rhs, cutoff, score, disqualifiers.iter(), &mut results);
+
+  (score.clamp(0.0, 1.0), results)
+}
+
 impl MatchingAlgorithm for LogicV1 {
   fn name() -> &'static str {
     "logic-v1"
@@ -71,32 +109,7 @@ impl MatchingAlgorithm for LogicV1 {
 
   #[instrument(name = "score_hit", skip_all, fields(entity_id = rhs.id))]
   fn score(bump: &Bump, lhs: &crate::model::SearchEntity, rhs: &crate::model::Entity, cutoff: f64) -> (f64, Vec<(&'static str, f64)>) {
-    if !rhs.schema.can_match(lhs.schema.as_str()) {
-      return (0.0, vec![]);
-    }
-
-    let mut results = Vec::with_capacity(FEATURES.len() + QUALIFIERS.len());
-    let mut score = 0.0f64;
-
-    for (func, weight) in FEATURES.iter() {
-      let span = info_span!("scoring_feature", feature = func.name());
-      let _span = span.enter();
-
-      let then = Instant::now();
-      let feature_score = func.score_feature(bump, lhs, rhs);
-
-      results.push((func.name(), feature_score));
-
-      if (feature_score * weight) > score {
-        score = feature_score * weight;
-      }
-
-      tracing::debug!(score = feature_score, latency = ?then.elapsed(), "computed feature score");
-    }
-
-    let score = run_features(bump, lhs, rhs, cutoff, score, QUALIFIERS.iter(), &mut results);
-
-    (score.clamp(0.0, 1.0), results)
+    logic_v1(bump, lhs, rhs, cutoff, &FEATURES, &[], &QUALIFIERS)
   }
 }
 

--- a/crates/libmotiva/src/matching/logic_v1.rs
+++ b/crates/libmotiva/src/matching/logic_v1.rs
@@ -1,11 +1,11 @@
-use std::{sync::LazyLock, time::Instant};
+use std::sync::LazyLock;
 
 use bumpalo::Bump;
-use tracing::{info_span, instrument};
+use tracing::instrument;
 
 use crate::{
   matching::{
-    Feature, MatchingAlgorithm,
+    Feature, FeaturesConfig, MatchingAlgorithm,
     matchers::{
       address::AddressEntityMatch,
       crypto_wallet::CryptoWalletMatch,
@@ -78,26 +78,10 @@ pub(crate) fn logic_v1(
   }
 
   let mut results = Vec::with_capacity(features.len() + qualifiers.len() + disqualifiers.len());
-  let mut score = 0.0f64;
 
-  for (func, weight) in features.iter() {
-    let span = info_span!("scoring_feature", feature = func.name());
-    let _span = span.enter();
-
-    let then = Instant::now();
-    let feature_score = func.score_feature(bump, lhs, rhs);
-
-    results.push((func.name(), feature_score));
-
-    if (feature_score * weight) > score {
-      score = feature_score * weight;
-    }
-
-    tracing::debug!(feature = func.name(), score = feature_score, latency = ?then.elapsed(), "computed feature score");
-  }
-
-  let score = run_features(bump, lhs, rhs, cutoff, score, qualifiers.iter(), &mut results);
-  let score = run_features(bump, lhs, rhs, cutoff, score, disqualifiers.iter(), &mut results);
+  let score = run_features(bump, lhs, rhs, 0.0, FeaturesConfig::highest_features(features), &mut results);
+  let score = run_features(bump, lhs, rhs, score, FeaturesConfig::summed_features(qualifiers), &mut results);
+  let score = run_features(bump, lhs, rhs, score, FeaturesConfig::disqualifiers(disqualifiers, cutoff), &mut results);
 
   (score.clamp(0.0, 1.0), results)
 }

--- a/crates/libmotiva/src/matching/marble_v0.rs
+++ b/crates/libmotiva/src/matching/marble_v0.rs
@@ -1,0 +1,224 @@
+use std::{sync::LazyLock, time::Instant};
+
+use bumpalo::Bump;
+use tracing::instrument;
+
+use crate::{
+  matching::{
+    Feature, MatchingAlgorithm,
+    matchers::{
+      address::AddressEntityMatch,
+      crypto_wallet::CryptoWalletMatch,
+      identifier::IdentifierMatch,
+      jaro_winkler::PersonNameJaroWinkler,
+      match_::{SimpleMatch, WeakAliasMatch},
+      mismatch::{NumbersMismatch, SimpleMismatch, dob_day_disjoint, dob_year_disjoint},
+      name_fingerprint_levenshtein::NameFingerprintLevenshtein,
+      name_literal_match::NameLiteralMatch,
+      orgid_mismatch::OrgIdMismatch,
+      phonetic::PersonNamePhoneticMatch,
+    },
+    run_features,
+    validators::{validate_bic, validate_imo_mmsi, validate_inn, validate_isin, validate_ogrn},
+  },
+  model::PropertyFilter,
+};
+
+/// Default matching algorithm
+pub struct MarbleV0;
+
+static FEATURES: LazyLock<Vec<(&'static dyn Feature, f64)>> = LazyLock::new(|| {
+  vec![
+    (&NameLiteralMatch, 1.0),
+    (&PersonNameJaroWinkler, 0.8),
+    (&PersonNamePhoneticMatch, 0.9),
+    (&NameFingerprintLevenshtein, 0.9),
+    // TODO: The weight of those two features are 0.0 by default, so until we
+    // implement a way to customize weights, there is no use implementing
+    // them:
+    //
+    //  - name_metaphone_match
+    //  - name_soundex_match
+    (&AddressEntityMatch, 0.98),
+    (&CryptoWalletMatch, 0.98),
+    (IdentifierMatch::new("isin_security_match", &["isin"], Some(validate_isin)), 0.98),
+    (IdentifierMatch::new("lei_code_match", &["leiCode"], Some(lei::validate)), 0.95),
+    (IdentifierMatch::new("ogrn_code_match", &["ogrnCode"], Some(validate_ogrn)), 0.95),
+    (IdentifierMatch::new("vessel_imo_mmsi_match", &["imoNumber", "mmsi"], Some(validate_imo_mmsi)), 0.95),
+    (IdentifierMatch::new("inn_code_match", &["innCode"], Some(validate_inn)), 0.95),
+    (IdentifierMatch::new("bic_code_match", &["bicCode"], Some(validate_bic)), 0.95),
+    (SimpleMatch::new("identifier_match", &|e| e.prop_group("identifier", PropertyFilter::All), None), 0.85), // TODO: add cleaning
+    (&WeakAliasMatch, 0.8),
+  ]
+});
+
+static QUALIFIERS: LazyLock<Vec<(&'static dyn Feature, f64)>> = LazyLock::new(|| {
+  vec![
+    (SimpleMismatch::new("country_mismatch", &|e| e.prop_group("country", PropertyFilter::All), None), -0.2),
+    (SimpleMismatch::new("last_name_mismatch", &|e| e.props(&["lastName"]), None), -0.2),
+    (SimpleMismatch::new("dob_year_disjoint", &|e| e.props(&["birthDate"]), Some(dob_year_disjoint)), -0.15),
+    (SimpleMismatch::new("dob_day_disjoint", &|e| e.props(&["birthDate"]), Some(dob_day_disjoint)), -0.2),
+    (SimpleMismatch::new("gender_mismatch", &|e| e.props(&["gender"]), None), -0.2),
+    (SimpleMismatch::new("identifier_mismatch", &|e| e.prop_group("identifier", PropertyFilter::All), None), -0.3),
+    (&OrgIdMismatch, -0.2),
+    (&NumbersMismatch, -0.1),
+  ]
+});
+
+impl MatchingAlgorithm for MarbleV0 {
+  fn name() -> &'static str {
+    "logic-v1"
+  }
+
+  #[instrument(name = "score_hit", skip_all, fields(entity_id = rhs.id))]
+  fn score(bump: &Bump, lhs: &crate::model::SearchEntity, rhs: &crate::model::Entity, cutoff: f64) -> (f64, Vec<(&'static str, f64)>) {
+    if !rhs.schema.can_match(lhs.schema.as_str()) {
+      return (0.0, vec![]);
+    }
+
+    let mut results = Vec::with_capacity(FEATURES.len() + QUALIFIERS.len());
+    let mut score = 0.0f64;
+
+    for (func, weight) in FEATURES.iter() {
+      let then = Instant::now();
+      let feature_score = func.score_feature(bump, lhs, rhs);
+
+      results.push((func.name(), feature_score));
+
+      if (feature_score * weight) > score {
+        score = feature_score * weight;
+      }
+
+      tracing::debug!(feature = func.name(), score = feature_score, latency = ?then.elapsed(), "computed feature score");
+    }
+
+    let score = run_features(bump, lhs, rhs, cutoff, score, QUALIFIERS.iter(), &mut results);
+
+    (score.clamp(0.0, 1.0), results)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use bumpalo::Bump;
+  use float_cmp::approx_eq;
+  use itertools::Itertools;
+  use pyo3::Python;
+
+  use crate::{
+    matching::{Algorithm, Feature, MatchingAlgorithm, logic_v1::LogicV1},
+    model::{Entity, SearchEntity},
+    tests::python::nomenklatura_score,
+  };
+
+  #[test]
+  fn logic_v1_person() {
+    let lhs = SearchEntity::builder("Person").properties(&[("name", &["Vladimir Bob Putain"])]).build();
+    let rhs = Entity::builder("Person")
+      .properties(&[("name", &["PUTIN vladimir vladimirovich", "PUTIN, Vladimir Vladimirovich", "Владимир Путин", "Vladimyr Bob Phutain"])])
+      .build();
+
+    let (score, features) = super::MarbleV0::score(&Bump::new(), &lhs, &rhs, 0.0);
+
+    assert!(approx_eq!(f64, score, 0.72, epsilon = 0.01));
+    assert!(approx_eq!(
+      f64,
+      features.iter().filter(|(name, _)| *name == "person_name_jaro_winkler").map(|(_, score)| *score).next().unwrap(),
+      0.9,
+      epsilon = 0.01
+    ));
+    assert!(features.iter().contains(&("person_name_phonetic_match", 2.0 / 3.0)));
+  }
+
+  #[test]
+  fn logic_v1_company() {
+    let lhs = SearchEntity::builder("Company")
+      .properties(&[("name", &["Google LLC"]), ("leiCode", &["529900T8BM49AURSDO55"]), ("ogrnCode", &["2022200525818"])])
+      .build();
+    let rhs = Entity::builder("Company")
+      .properties(&[
+        ("name", &["Gogole LIMITED LIABILITY COMPANY"]),
+        ("leiCode", &["LEI1234"]),
+        ("innCode", &["529900T8BM49AURSDO55", "2022200525818"]),
+      ])
+      .build();
+
+    let (score, features) = super::MarbleV0::score(&Bump::new(), &lhs, &rhs, 0.0);
+
+    assert_eq!(score, 0.95);
+    assert!(features.iter().contains(&("name_fingerprint_levenshtein", 7.0 / 9.0)));
+    assert!(features.iter().contains(&("lei_code_match", 1.0)));
+    assert!(features.iter().contains(&("ogrn_code_match", 1.0)));
+  }
+
+  #[test]
+  fn logic_v1_vessel() {
+    let lhs = SearchEntity::builder("Vessel").properties(&[("mmsi", &["366123456"])]).build();
+    let rhs = Entity::builder("Vessel").properties(&[("imoNumber", &["366123456"])]).build();
+
+    let (score, features) = super::MarbleV0::score(&Bump::new(), &lhs, &rhs, 0.0);
+
+    assert_eq!(score, 0.95);
+    assert!(features.iter().contains(&("vessel_imo_mmsi_match", 1.0)));
+  }
+
+  #[test]
+  fn person_name_jaro_winkler() {
+    let lhs = SearchEntity::builder("Person").properties(&[("name", &["Vladimir Putin"])]).build();
+    let rhs = Entity::builder("Person")
+      .properties(&[("name", &["PUTIN vladimir vladimirovich", "PUTIN, Vladimir Vladimirovich", "Владимир Путин"])])
+      .build();
+
+    assert_eq!(super::PersonNameJaroWinkler.score_feature(&Bump::new(), &lhs, &rhs), 1.0);
+  }
+
+  #[test]
+  fn person_name_phonetic_match() {
+    let lhs = SearchEntity::builder("Person").properties(&[("name", &["Vlodimir Bob Putain"])]).build();
+    let rhs = Entity::builder("Person")
+      .properties(&[("name", &["PUTIN vladimir vladimirovich", "PUTIN, Vladimir Vladimirovich", "Владимир Путин"])])
+      .build();
+
+    assert!(approx_eq!(f64, super::PersonNamePhoneticMatch.score_feature(&Bump::new(), &lhs, &rhs), 2.0 / 3.0));
+  }
+
+  #[test]
+  #[serial_test::serial]
+  fn against_nomenklatura() {
+    Python::initialize();
+
+    let queries = vec![
+      SearchEntity::builder("Person").properties(&[("name", &["Fladimir Poutine"]), ("gender", &["female"])]).build(),
+      SearchEntity::builder("Person")
+        .properties(&[("name", &["Fladimir Poutine"]), ("gender", &["female"]), ("country", &["cn"])])
+        .build(),
+      SearchEntity::builder("Company").properties(&[("name", &["Google"]), ("leiCode", &["529900T8BM49AURSDO55"])]).build(),
+      SearchEntity::builder("Vessel").properties(&[("name", &["Titanic"]), ("imoNumber", &["IMO8712345"])]).build(),
+      SearchEntity::builder("Address").properties(&[("full", &["No.3, Chabanais avenue, 103-222, Los Angeles"])]).build(),
+    ];
+
+    let results = vec![
+      Entity::builder("Person")
+        .id("Q7747")
+        .properties(&[("name", &["Vladimir Putin"]), ("gender", &["male"]), ("country", &["ru"])])
+        .build(),
+      Entity::builder("Person")
+        .id("Q7748")
+        .properties(&[("name", &["Barack Hussein Obama"]), ("gender", &["female"]), ("country", &["us"])])
+        .build(),
+      Entity::builder("Company").properties(&[("name", &["Gooogle"]), ("innCode", &["529900T8BM49AURSDO55"])]).build(),
+      Entity::builder("Vessel").properties(&[("name", &["Titanic"]), ("mssi", &["IMO8712345"])]).build(),
+      Entity::builder("Address").properties(&[("full", &["3 Chabanais ave, 103222, Los Angeles"])]).build(),
+    ];
+
+    for query in queries {
+      let nscores = nomenklatura_score(Algorithm::LogicV1, &query, results.clone()).unwrap();
+
+      for (index, (_, nscore)) in nscores.into_iter().enumerate() {
+        let (score, _) = LogicV1::score(&Bump::new(), &query, results.get(index).unwrap(), 0.0);
+
+        assert!(approx_eq!(f64, score, nscore, epsilon = 0.01));
+      }
+    }
+  }
+}

--- a/crates/libmotiva/src/matching/marble_v0.rs
+++ b/crates/libmotiva/src/matching/marble_v0.rs
@@ -10,11 +10,12 @@ use crate::{
     matchers::{
       address::AddressEntityMatch,
       crypto_wallet::CryptoWalletMatch,
+      dates::dob_progressive_match,
       identifier::IdentifierMatch,
       jaro_winkler::PersonNameJaroWinkler,
       marble::LongestCommonSubsequence,
       match_::{SimpleMatch, WeakAliasMatch},
-      mismatch::{NumbersMismatch, SimpleMismatch, dob_day_disjoint, dob_progressive_match, dob_year_disjoint},
+      mismatch::{NumbersMismatch, SimpleMismatch},
       name_fingerprint_levenshtein::NameFingerprintLevenshtein,
       name_literal_match::NameLiteralMatch,
       orgid_mismatch::OrgIdMismatch,
@@ -65,8 +66,6 @@ static DISQUALIFIERS: LazyLock<Vec<(&'static dyn Feature, f64)>> = LazyLock::new
   vec![
     (SimpleMismatch::new("country_mismatch", &|e| e.prop_group("country", PropertyFilter::All), None), -0.2),
     (SimpleMismatch::new("last_name_mismatch", &|e| e.props(&["lastName"]), None), -0.2),
-    (SimpleMismatch::new("dob_year_disjoint", &|e| e.props(&["birthDate"]), Some(dob_year_disjoint)), -0.15),
-    (SimpleMismatch::new("dob_day_disjoint", &|e| e.props(&["birthDate"]), Some(dob_day_disjoint)), -0.2),
     (SimpleMismatch::new("gender_mismatch", &|e| e.props(&["gender"]), None), -0.2),
     (SimpleMismatch::new("identifier_mismatch", &|e| e.prop_group("identifier", PropertyFilter::All), None), -0.3),
     (&OrgIdMismatch, -0.2),

--- a/crates/libmotiva/src/matching/marble_v0.rs
+++ b/crates/libmotiva/src/matching/marble_v0.rs
@@ -50,14 +50,14 @@ static FEATURES: LazyLock<Vec<(&'static dyn Feature, f64)>> = LazyLock::new(|| {
     (IdentifierMatch::new("vessel_imo_mmsi_match", &["imoNumber", "mmsi"], Some(validate_imo_mmsi)), 0.95),
     (IdentifierMatch::new("inn_code_match", &["innCode"], Some(validate_inn)), 0.95),
     (IdentifierMatch::new("bic_code_match", &["bicCode"], Some(validate_bic)), 0.95),
-    (SimpleMatch::new("identifier_match", &|e| e.prop_group("identifier", PropertyFilter::All), None), 0.85), // TODO: add cleaning
+    (SimpleMatch::new("identifier_match", &|e| e.prop_group("identifier", PropertyFilter::Matchable), None), 0.85), // TODO: add cleaning
     (&WeakAliasMatch, 0.8),
   ]
 });
 
 static QUALIFIERS: LazyLock<Vec<(&'static dyn Feature, f64)>> = LazyLock::new(|| {
   vec![
-    (SimpleMatch::new("country_match", &|e| e.prop_group("country", PropertyFilter::All), None), 0.1),
+    (SimpleMatch::new("country_match", &|e| e.prop_group("country", PropertyFilter::Matchable), None), 0.1),
     (SimpleMatch::new("dob_progressive_match", &|e| e.props(&["birthDate"]), Some(dob_progressive_match)), 0.15),
   ]
 });
@@ -67,7 +67,7 @@ static DISQUALIFIERS: LazyLock<Vec<(&'static dyn Feature, f64)>> = LazyLock::new
     (SimpleMismatch::new("country_mismatch", &|e| e.prop_group("country", PropertyFilter::All), None), -0.2),
     (SimpleMismatch::new("last_name_mismatch", &|e| e.props(&["lastName"]), None), -0.2),
     (SimpleMismatch::new("gender_mismatch", &|e| e.props(&["gender"]), None), -0.2),
-    (SimpleMismatch::new("identifier_mismatch", &|e| e.prop_group("identifier", PropertyFilter::All), None), -0.3),
+    (SimpleMismatch::new("identifier_mismatch", &|e| e.prop_group("identifier", PropertyFilter::Matchable), None), -0.3),
     (&OrgIdMismatch, -0.2),
     (&NumbersMismatch, -0.1),
   ]

--- a/crates/libmotiva/src/matching/marble_v0.rs
+++ b/crates/libmotiva/src/matching/marble_v0.rs
@@ -1,4 +1,4 @@
-use std::{sync::LazyLock, time::Instant};
+use std::sync::LazyLock;
 
 use bumpalo::Bump;
 use tracing::instrument;
@@ -6,19 +6,20 @@ use tracing::instrument;
 use crate::{
   matching::{
     Feature, MatchingAlgorithm,
+    logic_v1::logic_v1,
     matchers::{
       address::AddressEntityMatch,
       crypto_wallet::CryptoWalletMatch,
       identifier::IdentifierMatch,
       jaro_winkler::PersonNameJaroWinkler,
+      marble::LongestCommonSubsequence,
       match_::{SimpleMatch, WeakAliasMatch},
-      mismatch::{NumbersMismatch, SimpleMismatch, dob_day_disjoint, dob_year_disjoint},
+      mismatch::{NumbersMismatch, SimpleMismatch, dob_day_disjoint, dob_progressive_match, dob_year_disjoint},
       name_fingerprint_levenshtein::NameFingerprintLevenshtein,
       name_literal_match::NameLiteralMatch,
       orgid_mismatch::OrgIdMismatch,
       phonetic::PersonNamePhoneticMatch,
     },
-    run_features,
     validators::{validate_bic, validate_imo_mmsi, validate_inn, validate_isin, validate_ogrn},
   },
   model::PropertyFilter,
@@ -33,6 +34,7 @@ static FEATURES: LazyLock<Vec<(&'static dyn Feature, f64)>> = LazyLock::new(|| {
     (&PersonNameJaroWinkler, 0.8),
     (&PersonNamePhoneticMatch, 0.9),
     (&NameFingerprintLevenshtein, 0.9),
+    (&LongestCommonSubsequence, 0.8),
     // TODO: The weight of those two features are 0.0 by default, so until we
     // implement a way to customize weights, there is no use implementing
     // them:
@@ -54,6 +56,13 @@ static FEATURES: LazyLock<Vec<(&'static dyn Feature, f64)>> = LazyLock::new(|| {
 
 static QUALIFIERS: LazyLock<Vec<(&'static dyn Feature, f64)>> = LazyLock::new(|| {
   vec![
+    (SimpleMatch::new("country_match", &|e| e.prop_group("country", PropertyFilter::All), None), 0.1),
+    (SimpleMatch::new("dob_progressive_match", &|e| e.props(&["birthDate"]), Some(dob_progressive_match)), 0.15),
+  ]
+});
+
+static DISQUALIFIERS: LazyLock<Vec<(&'static dyn Feature, f64)>> = LazyLock::new(|| {
+  vec![
     (SimpleMismatch::new("country_mismatch", &|e| e.prop_group("country", PropertyFilter::All), None), -0.2),
     (SimpleMismatch::new("last_name_mismatch", &|e| e.props(&["lastName"]), None), -0.2),
     (SimpleMismatch::new("dob_year_disjoint", &|e| e.props(&["birthDate"]), Some(dob_year_disjoint)), -0.15),
@@ -67,34 +76,12 @@ static QUALIFIERS: LazyLock<Vec<(&'static dyn Feature, f64)>> = LazyLock::new(||
 
 impl MatchingAlgorithm for MarbleV0 {
   fn name() -> &'static str {
-    "logic-v1"
+    "marble-v0"
   }
 
   #[instrument(name = "score_hit", skip_all, fields(entity_id = rhs.id))]
   fn score(bump: &Bump, lhs: &crate::model::SearchEntity, rhs: &crate::model::Entity, cutoff: f64) -> (f64, Vec<(&'static str, f64)>) {
-    if !rhs.schema.can_match(lhs.schema.as_str()) {
-      return (0.0, vec![]);
-    }
-
-    let mut results = Vec::with_capacity(FEATURES.len() + QUALIFIERS.len());
-    let mut score = 0.0f64;
-
-    for (func, weight) in FEATURES.iter() {
-      let then = Instant::now();
-      let feature_score = func.score_feature(bump, lhs, rhs);
-
-      results.push((func.name(), feature_score));
-
-      if (feature_score * weight) > score {
-        score = feature_score * weight;
-      }
-
-      tracing::debug!(feature = func.name(), score = feature_score, latency = ?then.elapsed(), "computed feature score");
-    }
-
-    let score = run_features(bump, lhs, rhs, cutoff, score, QUALIFIERS.iter(), &mut results);
-
-    (score.clamp(0.0, 1.0), results)
+    logic_v1(bump, lhs, rhs, cutoff, &FEATURES, &QUALIFIERS, &DISQUALIFIERS)
   }
 }
 
@@ -103,16 +90,14 @@ mod tests {
   use bumpalo::Bump;
   use float_cmp::approx_eq;
   use itertools::Itertools;
-  use pyo3::Python;
 
   use crate::{
-    matching::{Algorithm, Feature, MatchingAlgorithm, logic_v1::LogicV1},
+    matching::{Feature, MatchingAlgorithm},
     model::{Entity, SearchEntity},
-    tests::python::nomenklatura_score,
   };
 
   #[test]
-  fn logic_v1_person() {
+  fn marble_v0_person() {
     let lhs = SearchEntity::builder("Person").properties(&[("name", &["Vladimir Bob Putain"])]).build();
     let rhs = Entity::builder("Person")
       .properties(&[("name", &["PUTIN vladimir vladimirovich", "PUTIN, Vladimir Vladimirovich", "Владимир Путин", "Vladimyr Bob Phutain"])])
@@ -131,7 +116,7 @@ mod tests {
   }
 
   #[test]
-  fn logic_v1_company() {
+  fn marble_v0_company() {
     let lhs = SearchEntity::builder("Company")
       .properties(&[("name", &["Google LLC"]), ("leiCode", &["529900T8BM49AURSDO55"]), ("ogrnCode", &["2022200525818"])])
       .build();
@@ -152,7 +137,7 @@ mod tests {
   }
 
   #[test]
-  fn logic_v1_vessel() {
+  fn marble_v0_vessel() {
     let lhs = SearchEntity::builder("Vessel").properties(&[("mmsi", &["366123456"])]).build();
     let rhs = Entity::builder("Vessel").properties(&[("imoNumber", &["366123456"])]).build();
 
@@ -183,42 +168,20 @@ mod tests {
   }
 
   #[test]
-  #[serial_test::serial]
-  fn against_nomenklatura() {
-    Python::initialize();
+  fn marble_v0_features() {
+    let lhs = SearchEntity::builder("Person")
+      .properties(&[("name", &["Samir Kamil AlAssad"]), ("country", &["sy"]), ("birthDate", &["1980-06-15"]), ("passportNumber", &["X111"])])
+      .build();
+    let rhs = Entity::builder("Person")
+      .properties(&[("name", &["Samer Kamel Al Asad"]), ("country", &["sy"]), ("birthDate", &["1980-06-15"]), ("passportNumber", &["Y999"])])
+      .build();
 
-    let queries = vec![
-      SearchEntity::builder("Person").properties(&[("name", &["Fladimir Poutine"]), ("gender", &["female"])]).build(),
-      SearchEntity::builder("Person")
-        .properties(&[("name", &["Fladimir Poutine"]), ("gender", &["female"]), ("country", &["cn"])])
-        .build(),
-      SearchEntity::builder("Company").properties(&[("name", &["Google"]), ("leiCode", &["529900T8BM49AURSDO55"])]).build(),
-      SearchEntity::builder("Vessel").properties(&[("name", &["Titanic"]), ("imoNumber", &["IMO8712345"])]).build(),
-      SearchEntity::builder("Address").properties(&[("full", &["No.3, Chabanais avenue, 103-222, Los Angeles"])]).build(),
-    ];
+    let (_, features) = super::MarbleV0::score(&Bump::new(), &lhs, &rhs, 0.0);
+    let feature_score = |name: &str| features.iter().find(|(n, _)| *n == name).map(|(_, score)| *score);
 
-    let results = vec![
-      Entity::builder("Person")
-        .id("Q7747")
-        .properties(&[("name", &["Vladimir Putin"]), ("gender", &["male"]), ("country", &["ru"])])
-        .build(),
-      Entity::builder("Person")
-        .id("Q7748")
-        .properties(&[("name", &["Barack Hussein Obama"]), ("gender", &["female"]), ("country", &["us"])])
-        .build(),
-      Entity::builder("Company").properties(&[("name", &["Gooogle"]), ("innCode", &["529900T8BM49AURSDO55"])]).build(),
-      Entity::builder("Vessel").properties(&[("name", &["Titanic"]), ("mssi", &["IMO8712345"])]).build(),
-      Entity::builder("Address").properties(&[("full", &["3 Chabanais ave, 103222, Los Angeles"])]).build(),
-    ];
-
-    for query in queries {
-      let nscores = nomenklatura_score(Algorithm::LogicV1, &query, results.clone()).unwrap();
-
-      for (index, (_, nscore)) in nscores.into_iter().enumerate() {
-        let (score, _) = LogicV1::score(&Bump::new(), &query, results.get(index).unwrap(), 0.0);
-
-        assert!(approx_eq!(f64, score, nscore, epsilon = 0.01));
-      }
-    }
+    assert!(feature_score("longest_common_subsequence").is_some_and(|score| score > 0.8));
+    assert_eq!(feature_score("country_match"), Some(1.0));
+    assert_eq!(feature_score("dob_progressive_match"), Some(1.0));
+    assert_eq!(feature_score("identifier_mismatch"), Some(1.0));
   }
 }

--- a/crates/libmotiva/src/matching/matchers/dates.rs
+++ b/crates/libmotiva/src/matching/matchers/dates.rs
@@ -1,0 +1,220 @@
+use compact_str::CompactString;
+use itertools::Itertools;
+use jiff::{
+  RoundMode, Unit,
+  civil::{Date, DateDifference},
+};
+
+pub(crate) fn dob_progressive_match<S: AsRef<str>>(lhs: &[S], rhs: &[S]) -> f64 {
+  const YEAR_EPSILON: u64 = 1;
+  const MONTH_EPSILON: i32 = 3;
+  const DAY_THRESHOLDS: (i32, i32) = (1, 60);
+
+  #[inline]
+  fn compare_year(lhs: u64, rhs: u64) -> f64 {
+    let diff = lhs.abs_diff(rhs);
+
+    if diff == 0 {
+      return 1.0;
+    }
+    if diff <= YEAR_EPSILON {
+      return 1.0 / (diff + 1) as f64;
+    }
+
+    -1.0
+  }
+
+  #[inline]
+  fn compare_months(diff: i32) -> f64 {
+    match diff.abs() {
+      0 => 1.0,
+      diff if diff >= MONTH_EPSILON => -1.0,
+      diff => 1.0 - (1.0 * (diff as f64 / MONTH_EPSILON as f64)),
+    }
+  }
+
+  #[inline]
+  fn compare_days(diff: i32) -> f64 {
+    match diff.abs() {
+      diff if diff <= DAY_THRESHOLDS.0 => 1.0,
+      diff if diff >= DAY_THRESHOLDS.1 => -1.0,
+      diff => (DAY_THRESHOLDS.1 - diff) as f64 / (DAY_THRESHOLDS.1 - DAY_THRESHOLDS.0) as f64,
+    }
+  }
+
+  #[inline]
+  fn swap_month_day(date: &str) -> Option<CompactString> {
+    if date.len() != 10 || !date.is_ascii() {
+      return None;
+    }
+
+    let reversed = date.as_bytes();
+
+    // Skip work if month == day
+    if reversed[5..7] == reversed[8..10] {
+      return None;
+    }
+
+    let mut out = [b'-'; 10];
+    out[0..4].copy_from_slice(&reversed[0..4]);
+    out[5..7].copy_from_slice(&reversed[8..10]);
+    out[8..10].copy_from_slice(&reversed[5..7]);
+
+    let swapped = std::str::from_utf8(&out).ok()?;
+
+    // Check if valid date
+    swapped.parse::<Date>().ok()?;
+
+    Some(CompactString::from(swapped))
+  }
+
+  #[inline]
+  fn score_pair(lhs: &str, rhs: &str) -> f64 {
+    if !lhs.is_ascii() || !rhs.is_ascii() {
+      return 0.0;
+    }
+
+    match (lhs.len(), rhs.len()) {
+      (4, other) | (other, 4) if other >= 4 => {
+        let Ok(lhs) = lhs[..4].parse::<u64>() else { return 0.0 };
+        let Ok(rhs) = rhs[..4].parse::<u64>() else { return 0.0 };
+
+        compare_year(lhs, rhs)
+      }
+
+      (7, other) | (other, 7) if other >= 7 => {
+        let mut ldate: std::vec::Vec<char> = lhs.chars().take(7).chain(['-', '1', '5']).collect();
+        let mut rdate: std::vec::Vec<char> = rhs.chars().take(7).chain(['-', '1', '5']).collect();
+
+        ldate[4] = '-';
+        rdate[4] = '-';
+
+        let Ok(ldate) = ldate.into_iter().take(10).collect::<CompactString>().parse::<Date>() else {
+          return 0.0;
+        };
+        let Ok(rdate) = rdate.into_iter().take(10).collect::<CompactString>().parse::<Date>() else {
+          return 0.0;
+        };
+
+        ldate
+          .min(rdate)
+          .until(DateDifference::new(ldate.max(rdate)).smallest(Unit::Month).mode(RoundMode::HalfExpand))
+          .map(|diff| compare_months(diff.get_months()))
+          .unwrap_or(0.0)
+      }
+
+      (10, other) | (other, 10) if other >= 10 => {
+        let mut ldate: std::vec::Vec<char> = lhs.chars().collect();
+        let mut rdate: std::vec::Vec<char> = rhs.chars().collect();
+
+        (ldate[4], ldate[7]) = ('-', '-');
+        (rdate[4], rdate[7]) = ('-', '-');
+
+        let Ok(ldate) = ldate.into_iter().collect::<CompactString>().parse::<Date>() else { return 0.0 };
+        let Ok(rdate) = rdate.into_iter().collect::<CompactString>().parse::<Date>() else { return 0.0 };
+
+        ldate
+          .min(rdate)
+          .until(DateDifference::new(ldate.max(rdate)).smallest(Unit::Day).mode(RoundMode::HalfExpand))
+          .map(|diff| compare_days(diff.get_days()))
+          .unwrap_or(0.0)
+      }
+
+      _ => 0.0,
+    }
+  }
+
+  let mut max = f64::MIN;
+
+  for (lhs, rhs) in lhs.iter().cartesian_product(rhs) {
+    let (lhs, rhs) = (lhs.as_ref(), rhs.as_ref());
+    let lswap = swap_month_day(lhs);
+
+    max = max.max(score_pair(lhs, rhs));
+
+    if let Some(lswap) = lswap.as_deref() {
+      let score = score_pair(lswap, rhs);
+
+      if score > 0.0 {
+        max = max.max(score * 0.5);
+      }
+    }
+  }
+
+  if max == f64::MIN {
+    return 0.0;
+  }
+
+  max
+}
+
+#[cfg(test)]
+mod tests {
+  use float_cmp::assert_approx_eq;
+
+  #[test]
+  fn dob_progressive_match() {
+    // Year level (YEAR_EPSILON = 1): exact => 1.0, one year off => 1/(diff+1), beyond => -1.0 (active mismatch).
+    assert_eq!(super::dob_progressive_match(&["1988"], &["1988"]), 1.0);
+    assert_eq!(super::dob_progressive_match(&["1988"], &["1989"]), 0.5);
+    assert_eq!(super::dob_progressive_match(&["1988"], &["1990"]), -1.0);
+
+    // Day level (DAY_THRESHOLDS = (1.0, 60.0)): (60 - diff) / 59 within range, -1.0 beyond.
+    assert_eq!(super::dob_progressive_match(&["1988-07-22"], &["1988-07-22"]), 1.0);
+    assert_eq!(super::dob_progressive_match(&["1988-07-22"], &["1988-07-27"]), 55.0 / 59.0);
+    assert_eq!(super::dob_progressive_match(&["1988-07-22"], &["1988-07-29"]), 53.0 / 59.0);
+    assert_eq!(super::dob_progressive_match(&["1988-07-22"], &["1990-07-22"]), -1.0);
+
+    // Day-level interpolation is symmetric.
+    let symmetric = super::dob_progressive_match(&["2021-01-01"], &["2021-02-10"]);
+    assert_eq!(symmetric, 20.0 / 59.0);
+    assert_eq!(super::dob_progressive_match(&["2021-02-10"], &["2021-01-01"]), symmetric);
+
+    // Non-dash separators are normalized before parsing.
+    assert_eq!(super::dob_progressive_match(&["1988/07/22"], &["1988.07.22"]), 1.0);
+
+    // The best pair across the cartesian product wins.
+    assert_eq!(super::dob_progressive_match(&["1970-01-01", "1988-07-22"], &["1988-07-24"]), 58.0 / 59.0);
+
+    // Comparing mixed precisions collapses to the coarser (shortest) level; the finer operand's extra digits are ignored.
+    assert_eq!(super::dob_progressive_match(&["1988"], &["1988-06"]), 1.0);
+    assert_eq!(super::dob_progressive_match(&["1989"], &["1988-06"]), 0.5);
+    assert_eq!(super::dob_progressive_match(&["1988"], &["1988-12-31"]), 1.0);
+    assert_eq!(super::dob_progressive_match(&["1988-07"], &["1988-07-31"]), 1.0);
+    assert_eq!(super::dob_progressive_match(&["1988-07-01"], &["1988-07-31"]), 30.0 / 59.0);
+
+    // Month level (MONTH_EPSILON = 3.0): a span beyond three months is an active mismatch.
+    assert_eq!(super::dob_progressive_match(&["1988-04"], &["1988-07"]), -1.0);
+    assert_approx_eq!(f64, super::dob_progressive_match(&["1988-05"], &["1988-06"]), 2.0 / 3.0);
+    assert_approx_eq!(f64, super::dob_progressive_match(&["1988-05"], &["1988-07"]), 1.0 / 3.0);
+    assert_eq!(super::dob_progressive_match(&["1988-05"], &["1988-08", "1988-05-31"]), 1.0);
+    assert_approx_eq!(f64, super::dob_progressive_match(&["1988-12"], &["1989-01"]), 2.0 / 3.0);
+    assert_eq!(super::dob_progressive_match(&["1988-12"], &["1989-12"]), -1.0);
+
+    // No dates can be compared (empty inputs or unparseable values) => 0.0, never a penalty.
+    assert_eq!(super::dob_progressive_match::<&str>(&[], &["1988"]), 0.0);
+    assert_eq!(super::dob_progressive_match::<&str>(&["1988"], &[]), 0.0);
+    assert_eq!(super::dob_progressive_match::<&str>(&[], &[]), 0.0);
+    assert_eq!(super::dob_progressive_match::<&str>(&[""], &[""]), 0.0);
+    assert_eq!(super::dob_progressive_match(&["1988-99-99"], &["1988-07-22"]), 0.0);
+    assert_eq!(super::dob_progressive_match(&["1988-99-99", "1988-07-22"], &["1988-07-24"]), 58.0 / 59.0);
+
+    // Swapping month and day (left-hand side only; a flipped match is weighted by 0.5).
+    assert_eq!(super::dob_progressive_match(&["1988-07-05"], &["1988-05-07"]), 0.5);
+    assert_eq!(super::dob_progressive_match(&["1988-05-11"], &["1988-11"]), 0.5);
+    assert_eq!(super::dob_progressive_match(&["1988-07-22"], &["1988-22-07"]), 0.0);
+
+    // A flipped interpretation only ever boosts toward a match; it must never soften a
+    // genuine mismatch penalty, even when the left-hand side has a valid transposition.
+    assert_eq!(super::dob_progressive_match(&["1988-07-05"], &["1995-07-05"]), -1.0);
+    assert_eq!(super::dob_progressive_match(&["1988-07-05"], &["1988-11-30"]), -1.0);
+    // A discounted flip does not override a stronger direct match.
+    assert_eq!(super::dob_progressive_match(&["1988-07-11"], &["1988-07-13"]), 58.0 / 59.0);
+
+    // Non-ASCII inputs
+    assert_eq!(super::dob_progressive_match(&["a💃xx"], &["1988"]), 0.0);
+    assert_eq!(super::dob_progressive_match(&["1988-07-22"], &["💃💃💃"]), 0.0);
+    assert_eq!(super::dob_progressive_match(&["1988💃07💃22"], &["1988-07-22"]), 0.0);
+    assert_eq!(super::dob_progressive_match(&["💃💃💃", "1988"], &["1988"]), 1.0);
+  }
+}

--- a/crates/libmotiva/src/matching/matchers/marble.rs
+++ b/crates/libmotiva/src/matching/matchers/marble.rs
@@ -1,0 +1,62 @@
+use alcs::FuzzyStrstr;
+use bumpalo::Bump;
+use libmotiva_macros::scoring_feature;
+
+use crate::{
+  Entity, HasProperties, SearchEntity,
+  matching::{
+    Feature, extractors,
+    replacers::{self, company_types::ORG_TYPES, stopwords::STOPWORDS},
+  },
+  model::PropertyFilter,
+};
+
+fn fingerprint_name(name: &str) -> String {
+  let output = replacers::replace(&STOPWORDS.0, &STOPWORDS.1, name);
+  let output = replacers::replace(&ORG_TYPES.0, &ORG_TYPES.1, &output);
+
+  output.trim().to_string()
+}
+
+#[scoring_feature(LongestCommonSubsequence, name = "longest_common_subsequence")]
+fn score_feature(&self, _bump: &Bump, lhs: &SearchEntity, rhs: &Entity) -> f64 {
+  let lhs_names = lhs.prop_group("name", PropertyFilter::All);
+  let rhs_names = rhs.prop_group("name", PropertyFilter::All);
+
+  let lhs_names = extractors::index_name_keys(lhs_names.iter()).map(|name| fingerprint_name(&name)).collect::<Vec<_>>();
+  let rhs_names = extractors::index_name_keys(rhs_names.iter());
+
+  let mut max = 0.0f64;
+
+  for rhs_name in rhs_names {
+    let rname = fingerprint_name(&rhs_name);
+
+    for lname in &lhs_names {
+      if let Some((score, _)) = rname.fuzzy_find_str(lname, 0.6) {
+        max = max.max(score as f64);
+      }
+    }
+  }
+
+  max
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::{
+    matching::{Feature, matchers::jaro_winkler::PersonNameJaroWinkler},
+    model::{Entity, SearchEntity},
+  };
+
+  use bumpalo::Bump;
+
+  #[test]
+  fn longest_common_subsequence() {
+    let lhs = SearchEntity::builder("Person").properties(&[("name", &["Samir Kamil AlAssad"])]).build();
+    let rhs = Entity::builder("Person").properties(&[("name", &["Samer Kamel Al Asad"])]).build();
+
+    // Sanity check that PersonNameJaroWinkler had a very bad scoring for this
+    assert!(PersonNameJaroWinkler.score_feature(&Bump::new(), &lhs, &rhs) < 0.3);
+    assert!(super::LongestCommonSubsequence.score_feature(&Bump::new(), &lhs, &rhs) > 0.8);
+  }
+}

--- a/crates/libmotiva/src/matching/matchers/mismatch.rs
+++ b/crates/libmotiva/src/matching/matchers/mismatch.rs
@@ -5,6 +5,11 @@ use bumpalo::{
   collections::{CollectIn, Vec},
 };
 use compact_str::CompactString;
+use itertools::Itertools;
+use jiff::{
+  SpanTotal, Unit,
+  civil::{Date, date},
+};
 use libmotiva_macros::scoring_feature;
 use tracing::instrument;
 
@@ -81,9 +86,110 @@ fn score_feature(&self, _bump: &Bump, lhs: &SearchEntity, rhs: &Entity) -> f64 {
   mismatches as f64 / base.max(1) as f64
 }
 
+pub(crate) fn dob_progressive_match<S: AsRef<str>>(lhs: &[S], rhs: &[S]) -> f64 {
+  const YEAR_EPSILON: u64 = 1;
+  const MONTH_EPSILON: f64 = 3.0;
+  const DAY_THRESHOLDS: (f64, f64) = (1.0, 60.0);
+
+  fn compare_year(lhs: u64, rhs: u64) -> f64 {
+    let diff = lhs.abs_diff(rhs);
+
+    if diff == 0 {
+      return 1.0;
+    }
+    if diff <= YEAR_EPSILON {
+      return 1.0 / (diff + 1) as f64;
+    }
+
+    0.0
+  }
+
+  fn compare_months(diff: f64) -> f64 {
+    match diff.abs() {
+      diff if diff > MONTH_EPSILON => 0.0,
+      diff => 1.0 / diff.max(1.0),
+    }
+  }
+
+  fn compare_days(diff: f64) -> f64 {
+    match diff.abs() {
+      diff if diff <= DAY_THRESHOLDS.0 => 1.0,
+      diff if diff > DAY_THRESHOLDS.1 => 0.0,
+      diff => (DAY_THRESHOLDS.1 - diff) / (DAY_THRESHOLDS.1 - DAY_THRESHOLDS.0),
+    }
+  }
+
+  let mut max = 0.0f64;
+
+  for (lhs, rhs) in lhs.iter().cartesian_product(rhs) {
+    let (lhs, rhs) = (lhs.as_ref(), rhs.as_ref());
+
+    if !lhs.is_ascii() || !rhs.is_ascii() {
+      continue;
+    }
+
+    match (lhs.len(), rhs.len()) {
+      (4, other) | (other, 4) if other >= 4 => {
+        let Ok(lhs) = lhs[..4].parse::<u64>() else { continue };
+        let Ok(rhs) = rhs[..4].parse::<u64>() else { continue };
+
+        max = max.max(compare_year(lhs, rhs));
+      }
+
+      (7, other) | (other, 7) if other >= 7 => {
+        let mut ldate: std::vec::Vec<char> = lhs.chars().chain(['-', '0', '1']).collect();
+        let mut rdate: std::vec::Vec<char> = rhs.chars().chain(['-', '0', '1']).collect();
+
+        ldate[4] = '-';
+        rdate[4] = '-';
+
+        let Ok(ldate) = ldate.into_iter().take(10).collect::<String>().parse::<Date>() else { continue };
+        let Ok(rdate) = rdate.into_iter().take(10).collect::<String>().parse::<Date>() else { continue };
+
+        if let Ok(diff) = (ldate - rdate).total((Unit::Month, date(2026, 1, 1))) {
+          max = max.max(compare_months(diff));
+        }
+      }
+
+      (10, other) | (other, 10) if other >= 10 => {
+        let mut ldate: std::vec::Vec<char> = lhs.chars().collect();
+        let mut rdate: std::vec::Vec<char> = rhs.chars().collect();
+
+        (ldate[4], ldate[7]) = ('-', '-');
+        (rdate[4], rdate[7]) = ('-', '-');
+
+        let Ok(ldate) = ldate.into_iter().collect::<String>().parse::<Date>() else { continue };
+        let Ok(rdate) = rdate.into_iter().collect::<String>().parse::<Date>() else { continue };
+
+        if let Ok(diff) = (ldate - rdate).total(SpanTotal::from(Unit::Day).days_are_24_hours()) {
+          max = max.max(compare_days(diff));
+        }
+      }
+
+      _ => {}
+    }
+  }
+
+  max
+}
+
 pub(crate) fn dob_year_disjoint<S: AsRef<str>>(bump: &Bump, lhs: &[S], rhs: &[S]) -> f64 {
-  let lhs_years = lhs.iter().map(|d| d.as_ref().chars().take(4).collect::<CompactString>()).collect_in::<Vec<_>>(bump);
-  let rhs_years = rhs.iter().map(|d| d.as_ref().chars().take(4).collect::<CompactString>()).collect_in::<Vec<_>>(bump);
+  // A date of birth is intrinsically invalid if it is not plain ASCII; such
+  // values are skipped so they neither match nor trigger a mismatch penalty.
+  let lhs_years = lhs
+    .iter()
+    .filter(|d| d.as_ref().is_ascii())
+    .map(|d| d.as_ref().chars().take(4).collect::<CompactString>())
+    .collect_in::<Vec<_>>(bump);
+  let rhs_years = rhs
+    .iter()
+    .filter(|d| d.as_ref().is_ascii())
+    .map(|d| d.as_ref().chars().take(4).collect::<CompactString>())
+    .collect_in::<Vec<_>>(bump);
+
+  if lhs_years.is_empty() || rhs_years.is_empty() {
+    return 0.0;
+  }
 
   match is_disjoint(&lhs_years, &rhs_years) {
     true => 1.0,
@@ -92,8 +198,10 @@ pub(crate) fn dob_year_disjoint<S: AsRef<str>>(bump: &Bump, lhs: &[S], rhs: &[S]
 }
 
 pub(crate) fn dob_day_disjoint<S: AsRef<str>>(bump: &Bump, lhs: &[S], rhs: &[S]) -> f64 {
-  let lhs_months = lhs.iter().filter(|d| d.as_ref().len() >= 10).map(extract_month_day).collect_in::<Vec<_>>(bump);
-  let rhs_months = rhs.iter().filter(|d| d.as_ref().len() >= 10).map(extract_month_day).collect_in::<Vec<_>>(bump);
+  // Non-ASCII dates are intrinsically invalid and are skipped; requiring ASCII
+  // also makes the byte length a valid proxy for the character count.
+  let lhs_months = lhs.iter().filter(|d| d.as_ref().is_ascii() && d.as_ref().len() >= 10).map(extract_month_day).collect_in::<Vec<_>>(bump);
+  let rhs_months = rhs.iter().filter(|d| d.as_ref().is_ascii() && d.as_ref().len() >= 10).map(extract_month_day).collect_in::<Vec<_>>(bump);
 
   if lhs_months.is_empty() || rhs_months.is_empty() {
     return 0.0;
@@ -135,6 +243,9 @@ mod tests {
     assert_eq!(super::dob_year_disjoint(&Bump::new(), &["1988/07/22"], &["1989x07x22"]), 1.0);
     assert_eq!(super::dob_year_disjoint(&Bump::new(), &["2022-07-22"], &["2022-07-22"]), 0.0);
     assert_eq!(super::dob_year_disjoint(&Bump::new(), &["2022x07x22"], &["2022+07+22"]), 0.0);
+
+    assert_eq!(super::dob_year_disjoint(&Bump::new(), &["1988💃07💃22"], &["1989-07-22"]), 0.0);
+    assert_eq!(super::dob_year_disjoint(&Bump::new(), &["1988💃07💃22", "1988-07-22"], &["1989-07-22"]), 1.0);
   }
 
   #[test]
@@ -146,7 +257,58 @@ mod tests {
     assert_eq!(super::dob_day_disjoint(&Bump::new(), &["2022-01-02"], &["2022-01-02"]), 0.0);
     assert_eq!(super::dob_day_disjoint(&Bump::new(), &["2022-01-02"], &["2022-02-01"]), 0.5);
     assert_eq!(super::dob_day_disjoint(&Bump::new(), &["1987-07-20", "2022-01-02"], &["2022-03-04", "1987-20-07"]), 0.5);
-    assert_eq!(super::dob_day_disjoint(&Bump::new(), &["1987/07/20", "2022o01o02"], &["2022*03*04", "1987💃20💃07"]), 0.5);
+    assert_eq!(super::dob_day_disjoint(&Bump::new(), &["1987/07/20", "2022o01o02"], &["2022*03*04", "1987*20*07"]), 0.5);
+
+    assert_eq!(super::dob_day_disjoint(&Bump::new(), &["1987-07-20"], &["1987💃20💃07"]), 0.0);
+    assert_eq!(super::dob_day_disjoint(&Bump::new(), &["1987-07-20"], &["1987💃20💃07", "1987-07-20"]), 0.0);
+    assert_eq!(super::dob_day_disjoint(&Bump::new(), &["1987-07-20"], &["1987💃20💃07", "1987-07-21"]), 1.0);
+  }
+
+  #[test]
+  fn dob_progressive_match() {
+    // Year level (YEAR_EPSILON = 1): exact => 1.0, one year off => 1/(diff+1), beyond => 0.0.
+    assert_eq!(super::dob_progressive_match(&["1988"], &["1988"]), 1.0);
+    assert_eq!(super::dob_progressive_match(&["1988"], &["1989"]), 0.5);
+    assert_eq!(super::dob_progressive_match(&["1988"], &["1990"]), 0.0);
+
+    // Day level (DAY_THRESHOLDS = (1.0, 60.0)): (60 - diff) / 59, clamped to [0, 1].
+    assert_eq!(super::dob_progressive_match(&["1988-07-22"], &["1988-07-22"]), 1.0);
+    assert!((super::dob_progressive_match(&["1988-07-22"], &["1988-07-27"]) - (60.0 - 5.0) / (60.0 - 1.0)).abs() < 1e-9);
+    assert!((super::dob_progressive_match(&["1988-07-22"], &["1988-07-29"]) - (60.0 - 7.0) / (60.0 - 1.0)).abs() < 1e-9);
+    assert_eq!(super::dob_progressive_match(&["1988-07-22"], &["1990-07-22"]), 0.0);
+
+    // Day-level interpolation is symmetric.
+    let interpolated = super::dob_progressive_match(&["2021-01-01"], &["2021-02-10"]);
+    assert!((interpolated - (60.0 - 40.0) / (60.0 - 1.0)).abs() < 1e-9);
+    assert_eq!(super::dob_progressive_match(&["2021-02-10"], &["2021-01-01"]), interpolated);
+
+    // Non-dash separators are normalized before parsing.
+    assert_eq!(super::dob_progressive_match(&["1988/07/22"], &["1988.07.22"]), 1.0);
+
+    // The best pair across the cartesian product wins.
+    assert!((super::dob_progressive_match(&["1970-01-01", "1988-07-22"], &["1988-07-24"]) - (60.0 - 2.0) / (60.0 - 1.0)).abs() < 1e-9);
+
+    // Comparing mixed precisions collapses to the coarser (shortest) level; the finer operand's extra digits are ignored.
+    assert_eq!(super::dob_progressive_match(&["1988"], &["1988-06"]), 1.0);
+    assert_eq!(super::dob_progressive_match(&["1989"], &["1988-06"]), 0.5);
+    assert_eq!(super::dob_progressive_match(&["1988"], &["1988-12-31"]), 1.0);
+    assert_eq!(super::dob_progressive_match(&["1988-07"], &["1988-07-31"]), 1.0);
+    assert!((super::dob_progressive_match(&["1988-07-01"], &["1988-07-31"]) - (60.0 - 30.0) / (60.0 - 1.0)).abs() < 1e-9);
+
+    // Month level (MONTH_EPSILON = 3.0): a span beyond three months is a mismatch.
+    assert_eq!(super::dob_progressive_match(&["1990-05"], &["1988-07"]), 0.0);
+
+    // Empty inputs and unparseable dates score 0.0.
+    assert_eq!(super::dob_progressive_match::<&str>(&[], &["1988"]), 0.0);
+    assert_eq!(super::dob_progressive_match::<&str>(&["1988"], &[]), 0.0);
+    assert_eq!(super::dob_progressive_match(&["1988-99-99"], &["1988-07-22"]), 0.0);
+    assert!((super::dob_progressive_match(&["1988-99-99", "1988-07-22"], &["1988-07-24"]) - (60.0 - 2.0) / (60.0 - 1.0)).abs() < 1e-9);
+
+    // Non-ASCII inputs
+    assert_eq!(super::dob_progressive_match(&["a💃xx"], &["1988"]), 0.0);
+    assert_eq!(super::dob_progressive_match(&["1988-07-22"], &["💃💃💃"]), 0.0);
+    assert_eq!(super::dob_progressive_match(&["1988💃07💃22"], &["1988-07-22"]), 0.0);
+    assert_eq!(super::dob_progressive_match(&["💃💃💃", "1988"], &["1988"]), 1.0);
   }
 
   #[test]

--- a/crates/libmotiva/src/matching/matchers/mismatch.rs
+++ b/crates/libmotiva/src/matching/matchers/mismatch.rs
@@ -5,11 +5,6 @@ use bumpalo::{
   collections::{CollectIn, Vec},
 };
 use compact_str::CompactString;
-use itertools::Itertools;
-use jiff::{
-  SpanTotal, Unit,
-  civil::{Date, date},
-};
 use libmotiva_macros::scoring_feature;
 use tracing::instrument;
 
@@ -84,93 +79,6 @@ fn score_feature(&self, _bump: &Bump, lhs: &SearchEntity, rhs: &Entity) -> f64 {
   let mismatches = lhs_numbers.difference(&rhs_numbers).count();
 
   mismatches as f64 / base.max(1) as f64
-}
-
-pub(crate) fn dob_progressive_match<S: AsRef<str>>(lhs: &[S], rhs: &[S]) -> f64 {
-  const YEAR_EPSILON: u64 = 1;
-  const MONTH_EPSILON: f64 = 3.0;
-  const DAY_THRESHOLDS: (f64, f64) = (1.0, 60.0);
-
-  fn compare_year(lhs: u64, rhs: u64) -> f64 {
-    let diff = lhs.abs_diff(rhs);
-
-    if diff == 0 {
-      return 1.0;
-    }
-    if diff <= YEAR_EPSILON {
-      return 1.0 / (diff + 1) as f64;
-    }
-
-    0.0
-  }
-
-  fn compare_months(diff: f64) -> f64 {
-    match diff.abs() {
-      diff if diff > MONTH_EPSILON => 0.0,
-      diff => 1.0 / diff.max(1.0),
-    }
-  }
-
-  fn compare_days(diff: f64) -> f64 {
-    match diff.abs() {
-      diff if diff <= DAY_THRESHOLDS.0 => 1.0,
-      diff if diff > DAY_THRESHOLDS.1 => 0.0,
-      diff => (DAY_THRESHOLDS.1 - diff) / (DAY_THRESHOLDS.1 - DAY_THRESHOLDS.0),
-    }
-  }
-
-  let mut max = 0.0f64;
-
-  for (lhs, rhs) in lhs.iter().cartesian_product(rhs) {
-    let (lhs, rhs) = (lhs.as_ref(), rhs.as_ref());
-
-    if !lhs.is_ascii() || !rhs.is_ascii() {
-      continue;
-    }
-
-    match (lhs.len(), rhs.len()) {
-      (4, other) | (other, 4) if other >= 4 => {
-        let Ok(lhs) = lhs[..4].parse::<u64>() else { continue };
-        let Ok(rhs) = rhs[..4].parse::<u64>() else { continue };
-
-        max = max.max(compare_year(lhs, rhs));
-      }
-
-      (7, other) | (other, 7) if other >= 7 => {
-        let mut ldate: std::vec::Vec<char> = lhs.chars().chain(['-', '0', '1']).collect();
-        let mut rdate: std::vec::Vec<char> = rhs.chars().chain(['-', '0', '1']).collect();
-
-        ldate[4] = '-';
-        rdate[4] = '-';
-
-        let Ok(ldate) = ldate.into_iter().take(10).collect::<String>().parse::<Date>() else { continue };
-        let Ok(rdate) = rdate.into_iter().take(10).collect::<String>().parse::<Date>() else { continue };
-
-        if let Ok(diff) = (ldate - rdate).total((Unit::Month, date(2026, 1, 1))) {
-          max = max.max(compare_months(diff));
-        }
-      }
-
-      (10, other) | (other, 10) if other >= 10 => {
-        let mut ldate: std::vec::Vec<char> = lhs.chars().collect();
-        let mut rdate: std::vec::Vec<char> = rhs.chars().collect();
-
-        (ldate[4], ldate[7]) = ('-', '-');
-        (rdate[4], rdate[7]) = ('-', '-');
-
-        let Ok(ldate) = ldate.into_iter().collect::<String>().parse::<Date>() else { continue };
-        let Ok(rdate) = rdate.into_iter().collect::<String>().parse::<Date>() else { continue };
-
-        if let Ok(diff) = (ldate - rdate).total(SpanTotal::from(Unit::Day).days_are_24_hours()) {
-          max = max.max(compare_days(diff));
-        }
-      }
-
-      _ => {}
-    }
-  }
-
-  max
 }
 
 pub(crate) fn dob_year_disjoint<S: AsRef<str>>(bump: &Bump, lhs: &[S], rhs: &[S]) -> f64 {
@@ -262,53 +170,6 @@ mod tests {
     assert_eq!(super::dob_day_disjoint(&Bump::new(), &["1987-07-20"], &["1987💃20💃07"]), 0.0);
     assert_eq!(super::dob_day_disjoint(&Bump::new(), &["1987-07-20"], &["1987💃20💃07", "1987-07-20"]), 0.0);
     assert_eq!(super::dob_day_disjoint(&Bump::new(), &["1987-07-20"], &["1987💃20💃07", "1987-07-21"]), 1.0);
-  }
-
-  #[test]
-  fn dob_progressive_match() {
-    // Year level (YEAR_EPSILON = 1): exact => 1.0, one year off => 1/(diff+1), beyond => 0.0.
-    assert_eq!(super::dob_progressive_match(&["1988"], &["1988"]), 1.0);
-    assert_eq!(super::dob_progressive_match(&["1988"], &["1989"]), 0.5);
-    assert_eq!(super::dob_progressive_match(&["1988"], &["1990"]), 0.0);
-
-    // Day level (DAY_THRESHOLDS = (1.0, 60.0)): (60 - diff) / 59, clamped to [0, 1].
-    assert_eq!(super::dob_progressive_match(&["1988-07-22"], &["1988-07-22"]), 1.0);
-    assert!((super::dob_progressive_match(&["1988-07-22"], &["1988-07-27"]) - (60.0 - 5.0) / (60.0 - 1.0)).abs() < 1e-9);
-    assert!((super::dob_progressive_match(&["1988-07-22"], &["1988-07-29"]) - (60.0 - 7.0) / (60.0 - 1.0)).abs() < 1e-9);
-    assert_eq!(super::dob_progressive_match(&["1988-07-22"], &["1990-07-22"]), 0.0);
-
-    // Day-level interpolation is symmetric.
-    let interpolated = super::dob_progressive_match(&["2021-01-01"], &["2021-02-10"]);
-    assert!((interpolated - (60.0 - 40.0) / (60.0 - 1.0)).abs() < 1e-9);
-    assert_eq!(super::dob_progressive_match(&["2021-02-10"], &["2021-01-01"]), interpolated);
-
-    // Non-dash separators are normalized before parsing.
-    assert_eq!(super::dob_progressive_match(&["1988/07/22"], &["1988.07.22"]), 1.0);
-
-    // The best pair across the cartesian product wins.
-    assert!((super::dob_progressive_match(&["1970-01-01", "1988-07-22"], &["1988-07-24"]) - (60.0 - 2.0) / (60.0 - 1.0)).abs() < 1e-9);
-
-    // Comparing mixed precisions collapses to the coarser (shortest) level; the finer operand's extra digits are ignored.
-    assert_eq!(super::dob_progressive_match(&["1988"], &["1988-06"]), 1.0);
-    assert_eq!(super::dob_progressive_match(&["1989"], &["1988-06"]), 0.5);
-    assert_eq!(super::dob_progressive_match(&["1988"], &["1988-12-31"]), 1.0);
-    assert_eq!(super::dob_progressive_match(&["1988-07"], &["1988-07-31"]), 1.0);
-    assert!((super::dob_progressive_match(&["1988-07-01"], &["1988-07-31"]) - (60.0 - 30.0) / (60.0 - 1.0)).abs() < 1e-9);
-
-    // Month level (MONTH_EPSILON = 3.0): a span beyond three months is a mismatch.
-    assert_eq!(super::dob_progressive_match(&["1990-05"], &["1988-07"]), 0.0);
-
-    // Empty inputs and unparseable dates score 0.0.
-    assert_eq!(super::dob_progressive_match::<&str>(&[], &["1988"]), 0.0);
-    assert_eq!(super::dob_progressive_match::<&str>(&["1988"], &[]), 0.0);
-    assert_eq!(super::dob_progressive_match(&["1988-99-99"], &["1988-07-22"]), 0.0);
-    assert!((super::dob_progressive_match(&["1988-99-99", "1988-07-22"], &["1988-07-24"]) - (60.0 - 2.0) / (60.0 - 1.0)).abs() < 1e-9);
-
-    // Non-ASCII inputs
-    assert_eq!(super::dob_progressive_match(&["a💃xx"], &["1988"]), 0.0);
-    assert_eq!(super::dob_progressive_match(&["1988-07-22"], &["💃💃💃"]), 0.0);
-    assert_eq!(super::dob_progressive_match(&["1988💃07💃22"], &["1988-07-22"]), 0.0);
-    assert_eq!(super::dob_progressive_match(&["💃💃💃", "1988"], &["1988"]), 1.0);
   }
 
   #[test]

--- a/crates/libmotiva/src/matching/matchers/mod.rs
+++ b/crates/libmotiva/src/matching/matchers/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod address;
 pub(crate) mod crypto_wallet;
 pub(crate) mod identifier;
 pub(crate) mod jaro_winkler;
+pub(crate) mod marble;
 pub(crate) mod match_;
 pub(crate) mod mismatch;
 pub(crate) mod name_fingerprint_levenshtein;

--- a/crates/libmotiva/src/matching/matchers/mod.rs
+++ b/crates/libmotiva/src/matching/matchers/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod address;
 pub(crate) mod crypto_wallet;
+pub(crate) mod dates;
 pub(crate) mod identifier;
 pub(crate) mod jaro_winkler;
 pub(crate) mod marble;

--- a/crates/libmotiva/src/matching/mod.rs
+++ b/crates/libmotiva/src/matching/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod comparers;
 pub(crate) mod extractors;
 pub(crate) mod latinize;
 pub(crate) mod logic_v1;
+pub(crate) mod marble_v0;
 pub(crate) mod name_based;
 pub(crate) mod name_qualified;
 pub(crate) mod replacers;
@@ -32,6 +33,8 @@ pub enum Algorithm {
   #[default]
   #[serde(rename = "logic-v1")]
   LogicV1,
+  #[serde(rename = "marble-v0")]
+  MarbleV0,
   #[serde(rename = "best")]
   Best,
 }
@@ -46,6 +49,7 @@ impl Algorithm {
       Algorithm::NameBased => "name-based",
       Algorithm::NameQualified => "name-qualified",
       Algorithm::LogicV1 => "logic-v1",
+      Algorithm::MarbleV0 => "marble-v0",
       Algorithm::Best => "best",
     }
   }

--- a/crates/libmotiva/src/matching/mod.rs
+++ b/crates/libmotiva/src/matching/mod.rs
@@ -77,19 +77,76 @@ pub trait Feature: Send + Sync {
   fn score_feature(&self, bump: &Bump, lhs: &SearchEntity, rhs: &Entity) -> f64;
 }
 
-fn run_features<'f, F>(bump: &Bump, lhs: &SearchEntity, rhs: &Entity, cutoff: f64, init: f64, features: F, results: &mut Vec<(&'static str, f64)>) -> f64
+pub struct FeaturesConfig<'f, F>
 where
   F: IntoIterator<Item = &'f (&'f dyn Feature, f64)>,
 {
-  features.into_iter().fold(init, move |score, (func, weight)| {
+  features: F,
+  behavior: FeaturesBehavior,
+  skip: FeaturesSkip,
+}
+
+impl<'f, F> FeaturesConfig<'f, F>
+where
+  F: IntoIterator<Item = &'f (&'f dyn Feature, f64)>,
+{
+  pub fn summed_features(features: F) -> Self {
+    Self {
+      features,
+      behavior: FeaturesBehavior::Sum,
+      skip: FeaturesSkip::Never,
+    }
+  }
+
+  pub fn highest_features(features: F) -> Self {
+    Self {
+      features,
+      behavior: FeaturesBehavior::Highest,
+      skip: FeaturesSkip::Never,
+    }
+  }
+
+  pub fn disqualifiers(features: F, cutoff: f64) -> Self {
+    Self {
+      features,
+      behavior: FeaturesBehavior::Sum,
+      skip: FeaturesSkip::ScoreBelow(cutoff),
+    }
+  }
+}
+
+#[derive(Clone, Copy)]
+pub enum FeaturesBehavior {
+  Highest,
+  Sum,
+}
+
+#[derive(Clone, Copy, Default)]
+pub enum FeaturesSkip {
+  #[default]
+  Never,
+  ScoreBelow(f64),
+}
+
+fn run_features<'f, F>(bump: &Bump, lhs: &SearchEntity, rhs: &Entity, init: f64, config: FeaturesConfig<'f, F>, results: &mut Vec<(&'static str, f64)>) -> f64
+where
+  F: IntoIterator<Item = &'f (&'f dyn Feature, f64)>,
+{
+  config.features.into_iter().fold(init, move |score, (func, weight)| {
+    if weight == &0.0 {
+      return score;
+    }
+
     let span = info_span!("scoring_feature", feature = func.name());
     let _span = span.enter();
 
-    // We assume all modifiers (with negative weights) tail the models, so if we
-    // are already below the cutoff, there is no way the score could go up
-    // again, so we skip the rest.
-    if score < cutoff && weight < &0.0 {
-      return score;
+    if let FeaturesSkip::ScoreBelow(cutoff) = config.skip {
+      // We assume all modifiers (with negative weights) tail the models, so if we
+      // are already below the cutoff, there is no way the score could go up
+      // again, so we skip the rest.
+      if score < cutoff && weight < &0.0 {
+        return score;
+      }
     }
 
     let then = Instant::now();
@@ -99,7 +156,13 @@ where
 
     tracing::debug!(score = feature_score, latency = ?then.elapsed(), "computed feature score");
 
-    score + (feature_score * weight)
+    let weighted = feature_score * weight;
+
+    match config.behavior {
+      FeaturesBehavior::Sum => score + weighted,
+      FeaturesBehavior::Highest if weighted > score => weighted,
+      _ => score,
+    }
   })
 }
 

--- a/crates/libmotiva/src/matching/name_based.rs
+++ b/crates/libmotiva/src/matching/name_based.rs
@@ -3,7 +3,7 @@ use tracing::instrument;
 
 use crate::{
   matching::{
-    Feature, MatchingAlgorithm,
+    Feature, FeaturesConfig, MatchingAlgorithm,
     matchers::{jaro_winkler::JaroNameParts, soundex::SoundexNameParts},
     run_features,
   },
@@ -21,13 +21,13 @@ impl MatchingAlgorithm for NameBased {
   }
 
   #[instrument(name = "score_hit", skip_all)]
-  fn score(bump: &Bump, lhs: &SearchEntity, rhs: &Entity, cutoff: f64) -> (f64, Vec<(&'static str, f64)>) {
+  fn score(bump: &Bump, lhs: &SearchEntity, rhs: &Entity, _cutoff: f64) -> (f64, Vec<(&'static str, f64)>) {
     if !rhs.schema.is_a(lhs.schema.as_str()) {
       return (0.0, vec![]);
     }
 
     let mut results = Vec::with_capacity(FEATURES.len());
-    let score = run_features(bump, lhs, rhs, 0.0, cutoff, FEATURES.iter(), &mut results);
+    let score = run_features(bump, lhs, rhs, 0.0, FeaturesConfig::summed_features(FEATURES), &mut results);
 
     (score.clamp(0.0, 1.0), results)
   }

--- a/crates/libmotiva/src/matching/name_qualified.rs
+++ b/crates/libmotiva/src/matching/name_qualified.rs
@@ -5,7 +5,7 @@ use tracing::instrument;
 
 use crate::{
   matching::{
-    Feature, MatchingAlgorithm,
+    Feature, FeaturesConfig, MatchingAlgorithm,
     matchers::{
       jaro_winkler::JaroNameParts,
       mismatch::{SimpleMismatch, dob_day_disjoint, dob_year_disjoint},
@@ -38,13 +38,13 @@ impl MatchingAlgorithm for NameQualified {
   }
 
   #[instrument(name = "score_hit", skip_all, fields(algorithm = Self::name(), entity_id = rhs.id))]
-  fn score(bump: &Bump, lhs: &SearchEntity, rhs: &Entity, cutoff: f64) -> (f64, Vec<(&'static str, f64)>) {
+  fn score(bump: &Bump, lhs: &SearchEntity, rhs: &Entity, _cutoff: f64) -> (f64, Vec<(&'static str, f64)>) {
     if !rhs.schema.is_a(lhs.schema.as_str()) {
       return (0.0, vec![]);
     }
 
     let mut results = Vec::with_capacity(FEATURES.len());
-    let score = run_features(bump, lhs, rhs, 0.0, cutoff, FEATURES.iter(), &mut results);
+    let score = run_features(bump, lhs, rhs, 0.0, FeaturesConfig::summed_features(FEATURES.iter()), &mut results);
 
     (score.clamp(0.0, 1.0), results)
   }

--- a/crates/libmotiva/src/scoring.rs
+++ b/crates/libmotiva/src/scoring.rs
@@ -32,7 +32,7 @@ pub fn score<A: MatchingAlgorithm>(entity: &SearchEntity, hits: Vec<Entity>, cut
     let (score, features) = A::score(&bump, entity, &hit, cutoff);
 
     hit.features = features;
-    hit.features.retain(|(_, score)| *score > 0.0);
+    hit.features.retain(|(_, score)| *score != 0.0);
 
     tracing::debug!(score = score, latency = ?then.elapsed(), "computed score");
 

--- a/crates/libmotiva/src/tests/python.rs
+++ b/crates/libmotiva/src/tests/python.rs
@@ -27,6 +27,7 @@ impl Algorithm {
     match self {
       Algorithm::NameBased => "NameMatcher",
       Algorithm::NameQualified => "NameQualifiedMatcher",
+      Algorithm::MarbleV0 => "MarbleV0",
       Algorithm::LogicV1 | Algorithm::Best => "LogicV1",
     }
   }

--- a/crates/motiva/src/api/handlers/match_entities.rs
+++ b/crates/motiva/src/api/handlers/match_entities.rs
@@ -74,6 +74,7 @@ pub async fn match_entities<F: CatalogFetcher, P: IndexProvider + 'static>(
         let scores = match query.algorithm {
           Algorithm::NameBased => state.motiva.score::<NameBased>(&entity, hits, query.cutoff),
           Algorithm::NameQualified => state.motiva.score::<NameQualified>(&entity, hits, query.cutoff),
+          Algorithm::MarbleV0 => state.motiva.score::<MarbleV0>(&entity, hits, query.cutoff),
           Algorithm::LogicV1 | Algorithm::Best => state.motiva.score::<LogicV1>(&entity, hits, query.cutoff),
         };
 


### PR DESCRIPTION
Introduce the `marble-v0` **experimental** matching algorithm

This PR adds a new, experimental matching algorithm — **`marble-v0`** — as an alternative to the existing default (`logic-v1`). It is fully opt-in: callers select it per request via the `algorithm` field, and existing behaviour is unchanged when it is not requested.

`marble-v0` builds on the same scoring foundation as `logic-v1` (name, identifier, address, and crypto-wallet features combined with qualifiers and penalties) and layers in a few tweaks aimed at better real-world matching quality for our use case.

### What's new

- **New selectable algorithm.** Clients can now pick `marble-v0` on the matching endpoint. `logic-v1` remains the default, so nothing changes unless the new algorithm is explicitly chosen.

- **Longest common subsequence name matching.** Adds a name-comparison signal that looks for the longest shared run of text between two names (after stripping company suffixes and stopwords). This helps catch matches where one name is embedded in or reordered within another, beyond what the existing name comparisons capture.

- **Progressive date-of-birth matching.** Instead of only penalising birth dates that clearly disagree, `marble-v0` also *rewards* birth dates that are close. Depending on how complete a date is (raw year, month or full date), we introduce leeway in comparing dates, with a linear depreciation of the score the further we get from it.

- **Country agreement as a positive signal.** Matching countries now contributes a small bonus, rather than country only ever acting as a mismatch penalty.

- **Identifier-mismatch penalty.** When both entities carry identifiers but they don't agree, the score is reduced. This lowers the confidence of matches that look similar by name but are contradicted by their identifiers. This feature is also backported into `logic-v1`, with a weight of 0.0 (disabled by default).

### Notes

- Experimental / V0: this is a first iteration intended for evaluation against the current default, not a replacement for it.
- No changes to the public API surface beyond the additional accepted `algorithm` value.
- Definitive weights and thresholds will be defined in a future PR.