### PR TITLE
Support custom weights for scoring features

### DIFF
--- a/crates/libmotiva/README.md
+++ b/crates/libmotiva/README.md
@@ -66,6 +66,7 @@ Motiva is configured via environment variables. The following variables are supp
 | `MANIFEST_URL`             | Optional URL to a custom manifest JSON file                                            | _(none)_                  |
 | `CATALOG_REFRESH_INTERVAL` | Interval at which to pull the manifest and catalogs                                    | _1h_                      |
 | `MATCH_CANDIDATES`         | Number of candidates to consider for matching                                          | `10`                      |
+| `WEIGHT_<FEATURE_NAME>`    | Custom weight for a given feature (e.g. `WEIGHT_PERSON_NAME_JARO_WINKLER`)             | _(none)_                  |
 | `ENRICHMENT_MAX_RECURSION` | Maximum recursion levels when enriching entities with relations                        | `2`                       |
 | `ENRICHMENT_QUERY_LIMIT`   | Maximum relation documents to fetch from Elasticsearch when building relation graphs   | `200`                     |
 | `ENABLE_PROMETHEUS`        | Enable Prometheus metrics collection and /metrics endpoint                             | `0`                       |

--- a/crates/libmotiva/benches/scoring.rs
+++ b/crates/libmotiva/benches/scoring.rs
@@ -15,7 +15,7 @@ fn name_based(c: &mut Criterion) {
     .flatten()
     .collect::<Vec<_>>();
 
-  c.bench_function("name_based", |b| b.iter(async || black_box(motiva.score::<NameBased>(&lhs, rhs.clone(), 0.5))));
+  c.bench_function("name_based", |b| b.iter(|| black_box(motiva.score::<NameBased>(&lhs, rhs.clone(), &Default::default()))));
 }
 
 fn name_qualified(c: &mut Criterion) {
@@ -28,7 +28,7 @@ fn name_qualified(c: &mut Criterion) {
     .flatten()
     .collect::<Vec<_>>();
 
-  c.bench_function("name_qualified", |b| b.iter(|| black_box(motiva.score::<NameQualified>(&lhs, rhs.clone(), 0.5))));
+  c.bench_function("name_qualified", |b| b.iter(|| black_box(motiva.score::<NameQualified>(&lhs, rhs.clone(), &Default::default()))));
 }
 
 fn logic_v1(c: &mut Criterion) {
@@ -41,7 +41,7 @@ fn logic_v1(c: &mut Criterion) {
     .flatten()
     .collect::<Vec<_>>();
 
-  c.bench_function("logic_v1", |b| b.iter(|| black_box(motiva.score::<LogicV1>(&lhs, rhs.clone(), 0.5))));
+  c.bench_function("logic_v1", |b| b.iter(|| black_box(motiva.score::<LogicV1>(&lhs, rhs.clone(), &Default::default()))));
 }
 
 criterion_group!(benches, name_based, name_qualified, logic_v1);

--- a/crates/libmotiva/src/lib.rs
+++ b/crates/libmotiva/src/lib.rs
@@ -38,7 +38,7 @@ pub mod prelude {
     elastic::{ElasticsearchProvider, builder::EsAuthMethod, builder::EsTlsVerification, config::EsOptions, scoped::create_scoped_index},
   };
   pub use crate::matching::{Algorithm, Feature, MatchParams, MatchingAlgorithm, logic_v1::LogicV1, marble_v0::MarbleV0, name_based::NameBased, name_qualified::NameQualified};
-  pub use crate::model::{Entity, HasProperties, SearchEntity};
+  pub use crate::model::{Entity, HasProperties, SearchEntity, format_score};
   pub use crate::scoring::ScoringOptions;
 }
 

--- a/crates/libmotiva/src/lib.rs
+++ b/crates/libmotiva/src/lib.rs
@@ -39,6 +39,7 @@ pub mod prelude {
   };
   pub use crate::matching::{Algorithm, Feature, MatchParams, MatchingAlgorithm, logic_v1::LogicV1, marble_v0::MarbleV0, name_based::NameBased, name_qualified::NameQualified};
   pub use crate::model::{Entity, HasProperties, SearchEntity};
+  pub use crate::scoring::ScoringOptions;
 }
 
 #[doc(inline)]

--- a/crates/libmotiva/src/matching/logic_v1.rs
+++ b/crates/libmotiva/src/matching/logic_v1.rs
@@ -22,6 +22,7 @@ use crate::{
     validators::{validate_bic, validate_imo_mmsi, validate_inn, validate_isin, validate_ogrn},
   },
   model::PropertyFilter,
+  scoring::ScoringOptions,
 };
 
 /// Default matching algorithm
@@ -69,7 +70,7 @@ pub(crate) fn logic_v1(
   bump: &Bump,
   lhs: &crate::model::SearchEntity,
   rhs: &crate::model::Entity,
-  cutoff: f64,
+  options: &ScoringOptions,
   features: &[(&'static dyn Feature, f64)],
   qualifiers: &[(&'static dyn Feature, f64)],
   disqualifiers: &[(&'static dyn Feature, f64)],
@@ -80,9 +81,9 @@ pub(crate) fn logic_v1(
 
   let mut results = Vec::with_capacity(features.len() + qualifiers.len() + disqualifiers.len());
 
-  let score = run_features(bump, lhs, rhs, 0.0, FeaturesConfig::highest_features(features), &mut results);
-  let score = run_features(bump, lhs, rhs, score, FeaturesConfig::summed_features(qualifiers), &mut results);
-  let score = run_features(bump, lhs, rhs, score, FeaturesConfig::disqualifiers(disqualifiers, cutoff), &mut results);
+  let score = run_features(bump, lhs, rhs, 0.0, FeaturesConfig::highest_features(&options.weights, features), &mut results);
+  let score = run_features(bump, lhs, rhs, score, FeaturesConfig::summed_features(&options.weights, qualifiers), &mut results);
+  let score = run_features(bump, lhs, rhs, score, FeaturesConfig::disqualifiers(&options.weights, disqualifiers, options.cutoff), &mut results);
 
   (score.clamp(0.0, 1.0), results)
 }
@@ -93,19 +94,22 @@ impl MatchingAlgorithm for LogicV1 {
   }
 
   #[instrument(name = "score_hit", skip_all, fields(entity_id = rhs.id))]
-  fn score(bump: &Bump, lhs: &crate::model::SearchEntity, rhs: &crate::model::Entity, cutoff: f64) -> (f64, Vec<(&'static str, f64)>) {
-    logic_v1(bump, lhs, rhs, cutoff, &FEATURES, &[], &QUALIFIERS)
+  fn score(bump: &Bump, lhs: &crate::model::SearchEntity, rhs: &crate::model::Entity, options: &ScoringOptions) -> (f64, Vec<(&'static str, f64)>) {
+    logic_v1(bump, lhs, rhs, options, &FEATURES, &[], &QUALIFIERS)
   }
 }
 
 #[cfg(test)]
 mod tests {
+  use std::collections::HashMap;
+
   use bumpalo::Bump;
   use float_cmp::approx_eq;
   use itertools::Itertools;
   use pyo3::Python;
 
   use crate::{
+    ScoringOptions,
     matching::{Algorithm, Feature, MatchingAlgorithm, logic_v1::LogicV1},
     model::{Entity, SearchEntity},
     tests::python::nomenklatura_score,
@@ -118,7 +122,7 @@ mod tests {
       .properties(&[("name", &["PUTIN vladimir vladimirovich", "PUTIN, Vladimir Vladimirovich", "Владимир Путин", "Vladimyr Bob Phutain"])])
       .build();
 
-    let (score, features) = super::LogicV1::score(&Bump::new(), &lhs, &rhs, 0.0);
+    let (score, features) = super::LogicV1::score(&Bump::new(), &lhs, &rhs, &Default::default());
 
     assert!(approx_eq!(f64, score, 0.72, epsilon = 0.01));
     assert!(approx_eq!(
@@ -143,7 +147,7 @@ mod tests {
       ])
       .build();
 
-    let (score, features) = super::LogicV1::score(&Bump::new(), &lhs, &rhs, 0.0);
+    let (score, features) = super::LogicV1::score(&Bump::new(), &lhs, &rhs, &Default::default());
 
     assert_eq!(score, 0.95);
     assert!(features.iter().contains(&("name_fingerprint_levenshtein", 7.0 / 9.0)));
@@ -156,7 +160,7 @@ mod tests {
     let lhs = SearchEntity::builder("Vessel").properties(&[("mmsi", &["366123456"])]).build();
     let rhs = Entity::builder("Vessel").properties(&[("imoNumber", &["366123456"])]).build();
 
-    let (score, features) = super::LogicV1::score(&Bump::new(), &lhs, &rhs, 0.0);
+    let (score, features) = super::LogicV1::score(&Bump::new(), &lhs, &rhs, &Default::default());
 
     assert_eq!(score, 0.95);
     assert!(features.iter().contains(&("vessel_imo_mmsi_match", 1.0)));
@@ -180,6 +184,23 @@ mod tests {
       .build();
 
     assert!(approx_eq!(f64, super::PersonNamePhoneticMatch.score_feature(&Bump::new(), &lhs, &rhs), 2.0 / 3.0));
+  }
+
+  #[test]
+  fn weighted() {
+    let lhs = SearchEntity::builder("Person").properties(&[("name", &["Exact Match"])]).build();
+    let rhs = Entity::builder("Person").properties(&[("name", &["Exact Match"])]).build();
+
+    let mut weights = HashMap::new();
+    weights.insert("name_literal_match".into(), 0.2);
+    weights.insert("person_name_jaro_winkler".into(), 0.2);
+    weights.insert("person_name_phonetic_match".into(), 0.2);
+
+    let options = ScoringOptions { weights, cutoff: 0.0 };
+    let (score, features) = super::LogicV1::score(&Bump::new(), &lhs, &rhs, &options);
+
+    assert!(features.contains(&("name_literal_match", 1.0)));
+    assert_eq!(score, 0.2);
   }
 
   #[test]
@@ -215,7 +236,7 @@ mod tests {
       let nscores = nomenklatura_score(Algorithm::LogicV1, &query, results.clone()).unwrap();
 
       for (index, (_, nscore)) in nscores.into_iter().enumerate() {
-        let (score, _) = LogicV1::score(&Bump::new(), &query, results.get(index).unwrap(), 0.0);
+        let (score, _) = LogicV1::score(&Bump::new(), &query, results.get(index).unwrap(), &ScoringOptions::new(0.0));
 
         assert!(approx_eq!(f64, score, nscore, epsilon = 0.01));
       }

--- a/crates/libmotiva/src/matching/marble_v0.rs
+++ b/crates/libmotiva/src/matching/marble_v0.rs
@@ -24,6 +24,7 @@ use crate::{
     validators::{validate_bic, validate_imo_mmsi, validate_inn, validate_isin, validate_ogrn},
   },
   model::PropertyFilter,
+  scoring::ScoringOptions,
 };
 
 /// Default matching algorithm
@@ -79,8 +80,8 @@ impl MatchingAlgorithm for MarbleV0 {
   }
 
   #[instrument(name = "score_hit", skip_all, fields(entity_id = rhs.id))]
-  fn score(bump: &Bump, lhs: &crate::model::SearchEntity, rhs: &crate::model::Entity, cutoff: f64) -> (f64, Vec<(&'static str, f64)>) {
-    logic_v1(bump, lhs, rhs, cutoff, &FEATURES, &QUALIFIERS, &DISQUALIFIERS)
+  fn score(bump: &Bump, lhs: &crate::model::SearchEntity, rhs: &crate::model::Entity, options: &ScoringOptions) -> (f64, Vec<(&'static str, f64)>) {
+    logic_v1(bump, lhs, rhs, options, &FEATURES, &QUALIFIERS, &DISQUALIFIERS)
   }
 }
 
@@ -102,7 +103,7 @@ mod tests {
       .properties(&[("name", &["PUTIN vladimir vladimirovich", "PUTIN, Vladimir Vladimirovich", "Владимир Путин", "Vladimyr Bob Phutain"])])
       .build();
 
-    let (score, features) = super::MarbleV0::score(&Bump::new(), &lhs, &rhs, 0.0);
+    let (score, features) = super::MarbleV0::score(&Bump::new(), &lhs, &rhs, &Default::default());
 
     assert!(approx_eq!(f64, score, 0.72, epsilon = 0.01));
     assert!(approx_eq!(
@@ -127,7 +128,7 @@ mod tests {
       ])
       .build();
 
-    let (score, features) = super::MarbleV0::score(&Bump::new(), &lhs, &rhs, 0.0);
+    let (score, features) = super::MarbleV0::score(&Bump::new(), &lhs, &rhs, &Default::default());
 
     assert_eq!(score, 0.95);
     assert!(features.iter().contains(&("name_fingerprint_levenshtein", 7.0 / 9.0)));
@@ -140,7 +141,7 @@ mod tests {
     let lhs = SearchEntity::builder("Vessel").properties(&[("mmsi", &["366123456"])]).build();
     let rhs = Entity::builder("Vessel").properties(&[("imoNumber", &["366123456"])]).build();
 
-    let (score, features) = super::MarbleV0::score(&Bump::new(), &lhs, &rhs, 0.0);
+    let (score, features) = super::MarbleV0::score(&Bump::new(), &lhs, &rhs, &Default::default());
 
     assert_eq!(score, 0.95);
     assert!(features.iter().contains(&("vessel_imo_mmsi_match", 1.0)));
@@ -175,7 +176,7 @@ mod tests {
       .properties(&[("name", &["Samer Kamel Al Asad"]), ("country", &["sy"]), ("birthDate", &["1980-06-15"]), ("passportNumber", &["Y999"])])
       .build();
 
-    let (_, features) = super::MarbleV0::score(&Bump::new(), &lhs, &rhs, 0.0);
+    let (_, features) = super::MarbleV0::score(&Bump::new(), &lhs, &rhs, &Default::default());
     let feature_score = |name: &str| features.iter().find(|(n, _)| *n == name).map(|(_, score)| *score);
 
     assert!(feature_score("longest_common_subsequence").is_some_and(|score| score > 0.8));

--- a/crates/libmotiva/src/matching/mod.rs
+++ b/crates/libmotiva/src/matching/mod.rs
@@ -3,7 +3,7 @@ mod matchers;
 #[cfg(test)]
 mod tests;
 
-use std::time::Instant;
+use std::{collections::HashMap, time::Instant};
 
 use bumpalo::Bump;
 use jiff::Timestamp;
@@ -11,7 +11,10 @@ use serde::Deserialize;
 use serde_inline_default::serde_inline_default;
 use tracing::info_span;
 
-use crate::model::{Entity, SearchEntity};
+use crate::{
+  model::{Entity, SearchEntity},
+  scoring::ScoringOptions,
+};
 
 pub(crate) mod comparers;
 pub(crate) mod extractors;
@@ -66,7 +69,7 @@ pub trait MatchingAlgorithm {
   ///
   /// It returns a tuple of the resulting score and a vector of features and
   /// their resulting score.
-  fn score(bump: &Bump, lhs: &SearchEntity, rhs: &Entity, cutoff: f64) -> (f64, Vec<(&'static str, f64)>);
+  fn score(bump: &Bump, lhs: &SearchEntity, rhs: &Entity, options: &ScoringOptions) -> (f64, Vec<(&'static str, f64)>);
 }
 
 /// A scoring facet composed into a [`MatchingAlgorithm`]
@@ -81,6 +84,7 @@ pub struct FeaturesConfig<'f, F>
 where
   F: IntoIterator<Item = &'f (&'f dyn Feature, f64)>,
 {
+  weights: &'f HashMap<String, f64>,
   features: F,
   behavior: FeaturesBehavior,
   skip: FeaturesSkip,
@@ -90,24 +94,27 @@ impl<'f, F> FeaturesConfig<'f, F>
 where
   F: IntoIterator<Item = &'f (&'f dyn Feature, f64)>,
 {
-  pub fn summed_features(features: F) -> Self {
+  pub fn summed_features(weights: &'f HashMap<String, f64>, features: F) -> Self {
     Self {
+      weights,
       features,
       behavior: FeaturesBehavior::Sum,
       skip: FeaturesSkip::Never,
     }
   }
 
-  pub fn highest_features(features: F) -> Self {
+  pub fn highest_features(weights: &'f HashMap<String, f64>, features: F) -> Self {
     Self {
+      weights,
       features,
       behavior: FeaturesBehavior::Highest,
       skip: FeaturesSkip::Never,
     }
   }
 
-  pub fn disqualifiers(features: F, cutoff: f64) -> Self {
+  pub fn disqualifiers(weights: &'f HashMap<String, f64>, features: F, cutoff: f64) -> Self {
     Self {
+      weights,
       features,
       behavior: FeaturesBehavior::Sum,
       skip: FeaturesSkip::ScoreBelow(cutoff),
@@ -133,6 +140,8 @@ where
   F: IntoIterator<Item = &'f (&'f dyn Feature, f64)>,
 {
   config.features.into_iter().fold(init, move |score, (func, weight)| {
+    let weight = config.weights.get(func.name()).unwrap_or(weight);
+
     if weight == &0.0 {
       return score;
     }

--- a/crates/libmotiva/src/matching/name_based.rs
+++ b/crates/libmotiva/src/matching/name_based.rs
@@ -8,6 +8,7 @@ use crate::{
     run_features,
   },
   model::{Entity, SearchEntity},
+  scoring::ScoringOptions,
 };
 
 /// Simple matching algorithm using name similarity
@@ -21,13 +22,13 @@ impl MatchingAlgorithm for NameBased {
   }
 
   #[instrument(name = "score_hit", skip_all)]
-  fn score(bump: &Bump, lhs: &SearchEntity, rhs: &Entity, _cutoff: f64) -> (f64, Vec<(&'static str, f64)>) {
+  fn score(bump: &Bump, lhs: &SearchEntity, rhs: &Entity, options: &ScoringOptions) -> (f64, Vec<(&'static str, f64)>) {
     if !rhs.schema.is_a(lhs.schema.as_str()) {
       return (0.0, vec![]);
     }
 
     let mut results = Vec::with_capacity(FEATURES.len());
-    let score = run_features(bump, lhs, rhs, 0.0, FeaturesConfig::summed_features(FEATURES), &mut results);
+    let score = run_features(bump, lhs, rhs, 0.0, FeaturesConfig::summed_features(&options.weights, FEATURES), &mut results);
 
     (score.clamp(0.0, 1.0), results)
   }
@@ -40,6 +41,7 @@ mod tests {
   use pyo3::Python;
 
   use crate::{
+    ScoringOptions,
     matching::{Algorithm, MatchingAlgorithm, name_based::NameBased},
     model::{Entity, SearchEntity},
     tests::python::nomenklatura_score,
@@ -55,7 +57,7 @@ mod tests {
     let e1 = SearchEntity::builder("Person").properties(&[("name", &["Vladimir Putin"])]).build();
     let e2 = Entity::builder("Company").properties(&[("name", &["Vladimir Putin"])]).build();
 
-    let (score, _) = NameBased::score(&Bump::new(), &e1, &e2, 0.0);
+    let (score, _) = NameBased::score(&Bump::new(), &e1, &e2, &Default::default());
 
     assert_eq!(score, 0.0);
   }
@@ -65,7 +67,7 @@ mod tests {
     let e1 = SearchEntity::builder("Person").properties(&[("name", &["Vladimir Putin"])]).build();
     let e2 = Entity::builder("Person").properties(&[("name", &["Vladimir Putin"])]).build();
 
-    let (score, _) = NameBased::score(&Bump::new(), &e1, &e2, 0.0);
+    let (score, _) = NameBased::score(&Bump::new(), &e1, &e2, &Default::default());
 
     assert_eq!(score, 1.0);
   }
@@ -99,7 +101,7 @@ mod tests {
     let nscores = nomenklatura_score(Algorithm::NameBased, &query, results.clone()).unwrap();
 
     for (index, (_, nscore)) in nscores.into_iter().enumerate() {
-      let (score, _) = NameBased::score(&Bump::new(), &query, results.get(index).unwrap(), 0.0);
+      let (score, _) = NameBased::score(&Bump::new(), &query, results.get(index).unwrap(), &ScoringOptions::new(0.0));
 
       assert!(approx_eq!(f64, score, nscore, epsilon = 0.05));
     }

--- a/crates/libmotiva/src/matching/name_qualified.rs
+++ b/crates/libmotiva/src/matching/name_qualified.rs
@@ -15,6 +15,7 @@ use crate::{
     run_features,
   },
   model::{Entity, SearchEntity},
+  scoring::ScoringOptions,
 };
 
 /// Simple matching algorithm using name similarity, and penalty for disjoint attributes
@@ -38,13 +39,13 @@ impl MatchingAlgorithm for NameQualified {
   }
 
   #[instrument(name = "score_hit", skip_all, fields(algorithm = Self::name(), entity_id = rhs.id))]
-  fn score(bump: &Bump, lhs: &SearchEntity, rhs: &Entity, _cutoff: f64) -> (f64, Vec<(&'static str, f64)>) {
+  fn score(bump: &Bump, lhs: &SearchEntity, rhs: &Entity, options: &ScoringOptions) -> (f64, Vec<(&'static str, f64)>) {
     if !rhs.schema.is_a(lhs.schema.as_str()) {
       return (0.0, vec![]);
     }
 
     let mut results = Vec::with_capacity(FEATURES.len());
-    let score = run_features(bump, lhs, rhs, 0.0, FeaturesConfig::summed_features(FEATURES.iter()), &mut results);
+    let score = run_features(bump, lhs, rhs, 0.0, FeaturesConfig::summed_features(&options.weights, FEATURES.iter()), &mut results);
 
     (score.clamp(0.0, 1.0), results)
   }
@@ -57,6 +58,7 @@ mod tests {
   use pyo3::Python;
 
   use crate::{
+    ScoringOptions,
     matching::{Algorithm, MatchingAlgorithm, name_qualified::NameQualified},
     model::{Entity, SearchEntity},
     tests::python::nomenklatura_score,
@@ -72,7 +74,7 @@ mod tests {
     let e1 = SearchEntity::builder("Person").properties(&[("name", &["Vladimir Putin"])]).build();
     let e2 = Entity::builder("Company").properties(&[("name", &["Vladimir Putin"])]).build();
 
-    let (score, _) = NameQualified::score(&Bump::new(), &e1, &e2, 0.0);
+    let (score, _) = NameQualified::score(&Bump::new(), &e1, &e2, &Default::default());
 
     assert_eq!(score, 0.0);
   }
@@ -165,7 +167,7 @@ mod tests {
       let nscores = nomenklatura_score(Algorithm::NameQualified, &query, results.clone()).unwrap();
 
       for (index, (_, nscore)) in nscores.into_iter().enumerate() {
-        let (score, _) = NameQualified::score(&Bump::new(), &query, results.get(index).unwrap(), 0.0);
+        let (score, _) = NameQualified::score(&Bump::new(), &query, results.get(index).unwrap(), &ScoringOptions::new(0.0));
 
         assert!(
           approx_eq!(f64, score, nscore, epsilon = 0.01),
@@ -193,7 +195,7 @@ mod tests {
       let nscores = nomenklatura_score(Algorithm::NameQualified, &query, results.clone()).unwrap();
 
       for (index, (_, nscore)) in nscores.into_iter().enumerate() {
-        let (score, _) = NameQualified::score(&Bump::new(), &query, results.get(index).unwrap(), 0.0);
+        let (score, _) = NameQualified::score(&Bump::new(), &query, results.get(index).unwrap(), &ScoringOptions::new(0.0));
 
         assert!(approx_eq!(f64, score, nscore, epsilon = 0.01));
       }

--- a/crates/libmotiva/src/matching/tests/comprehensive.rs
+++ b/crates/libmotiva/src/matching/tests/comprehensive.rs
@@ -268,7 +268,7 @@ mod tests {
 
       for (index, (_, nscore)) in nscores.into_iter().enumerate() {
         let candidate = candidates.get(index).unwrap();
-        let (score, _) = LogicV1::score(&Bump::new(), &query, candidate, 0.0);
+        let (score, _) = LogicV1::score(&Bump::new(), &query, candidate, &Default::default());
 
         assert!(
           approx_eq!(f64, score, nscore, epsilon = 0.01),

--- a/crates/libmotiva/src/model.rs
+++ b/crates/libmotiva/src/model.rs
@@ -388,7 +388,7 @@ fn features_to_map<S: Serializer>(input: &[(&'static str, f64)], ser: S) -> Resu
 
   let mut map = ser.serialize_map(Some(input.len()))?;
   for (k, v) in input {
-    map.serialize_entry(k, &v)?;
+    map.serialize_entry(k, &format_score(*v))?;
   }
   map.end()
 }
@@ -462,6 +462,14 @@ impl Entity {
       ..Default::default()
     }
   }
+}
+
+#[inline]
+pub fn format_score(score: f64) -> f64 {
+  const SCORE_DECIMALS: u32 = 3;
+  const MULTIPLIER: f64 = 10u32.pow(SCORE_DECIMALS) as f64;
+
+  (score * MULTIPLIER).round() / MULTIPLIER
 }
 
 #[cfg(test)]

--- a/crates/libmotiva/src/motiva.rs
+++ b/crates/libmotiva/src/motiva.rs
@@ -15,7 +15,7 @@ use crate::{
   model::{Entity, SearchEntity},
   nested::fetch_nested_entities,
   prelude::MatchingAlgorithm,
-  scoring,
+  scoring::{self, ScoringOptions},
 };
 
 /// Whether to fetch related entities.
@@ -73,7 +73,7 @@ pub struct MotivaConfig {
 ///
 ///   let search = SearchEntity::builder("Person").properties(&[("name", &["John Doe"])]).build();
 ///   let results = motiva.search(&search, &MatchParams::default()).await.unwrap();
-///   let scores = motiva.score::<NameBased>(&search, results, 0.5).unwrap();
+///   let scores = motiva.score::<NameBased>(&search, results, &Default::default()).unwrap();
 ///
 ///   for (entity, score) in scores {
 ///       if let Some(name) = entity.props(&["name"]).iter().next() {
@@ -217,8 +217,8 @@ impl<P: IndexProvider, F: CatalogFetcher> Motiva<P, F> {
   }
 
   /// Perform the scoring of all candidates against the search parameters.
-  pub fn score<A: MatchingAlgorithm>(&self, entity: &SearchEntity, hits: Vec<Entity>, cutoff: f64) -> anyhow::Result<Vec<(Entity, f64)>> {
-    scoring::score::<A>(entity, hits, cutoff)
+  pub fn score<A: MatchingAlgorithm>(&self, entity: &SearchEntity, hits: Vec<Entity>, options: &ScoringOptions) -> anyhow::Result<Vec<(Entity, f64)>> {
+    scoring::score::<A>(entity, hits, options)
   }
 
   /// Refresh the local catalog from upstream.

--- a/crates/libmotiva/src/scoring.rs
+++ b/crates/libmotiva/src/scoring.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use bumpalo::Bump;
 
 use metrics::histogram;
@@ -11,8 +13,20 @@ use crate::{
   model::{Entity, SearchEntity},
 };
 
+#[derive(Debug, Default)]
+pub struct ScoringOptions {
+  pub cutoff: f64,
+  pub weights: HashMap<String, f64>,
+}
+
+impl ScoringOptions {
+  pub fn new(cutoff: f64) -> Self {
+    ScoringOptions { cutoff, weights: Default::default() }
+  }
+}
+
 #[instrument(name = "compute_scores", skip_all, fields(algorithm = A::name()))]
-pub fn score<A: MatchingAlgorithm>(entity: &SearchEntity, hits: Vec<Entity>, cutoff: f64) -> anyhow::Result<Vec<(Entity, f64)>> {
+pub fn score<A: MatchingAlgorithm>(entity: &SearchEntity, hits: Vec<Entity>, options: &ScoringOptions) -> anyhow::Result<Vec<(Entity, f64)>> {
   let span = Span::current();
 
   let mut bump = Bump::with_capacity(1024);
@@ -29,7 +43,7 @@ pub fn score<A: MatchingAlgorithm>(entity: &SearchEntity, hits: Vec<Entity>, cut
       return (hit, 0.0);
     }
 
-    let (score, features) = A::score(&bump, entity, &hit, cutoff);
+    let (score, features) = A::score(&bump, entity, &hit, options);
 
     hit.features = features;
     hit.features.retain(|(_, score)| *score != 0.0);
@@ -62,7 +76,7 @@ mod tests {
   fn incomparable_schemas() {
     let lhs = SearchEntity::builder("Person").properties(&[("name", &["Vladimir Putin"])]).build();
     let rhs = Entity::builder("Company").properties(&[("name", &["Vladimir Putin"])]).build();
-    let result = super::score::<LogicV1>(&lhs, vec![rhs], 0.0).unwrap();
+    let result = super::score::<LogicV1>(&lhs, vec![rhs], &Default::default()).unwrap();
 
     assert_eq!(result.len(), 1);
     assert!(approx_eq!(f64, result[0].1, 0.0));

--- a/crates/motiva/src/api/config.rs
+++ b/crates/motiva/src/api/config.rs
@@ -1,4 +1,5 @@
 use std::{
+  collections::HashMap,
   env::{self, VarError},
   fmt::Display,
   fs,
@@ -33,6 +34,7 @@ pub struct Config {
   pub catalog_refresh_interval: Span,
   pub outdated_grace: Span,
   pub match_candidates: usize,
+  pub weights: HashMap<String, f64>,
 
   // Enrichment settings
   pub enrichment_max_recursion: usize,
@@ -54,6 +56,7 @@ impl Config {
       listener: None,
       api_key: env::var("API_KEY").ok(),
       match_candidates: parse_env("MATCH_CANDIDATES", 10)?,
+      weights: parse_weights_from_env()?,
       manifest_url: env::var("MANIFEST_URL").ok(),
       request_timeout: parse_env("REQUEST_TIMEOUT", Span::from_str("10s").unwrap())?,
       catalog_refresh_interval: parse_env("CATALOG_REFRESH_INTERVAL", Span::from_str("1h").unwrap())?,
@@ -149,6 +152,25 @@ where
       _ => Err(AppError::ConfigError(format!("could not read {name}: {err}")).into()),
     },
   }
+}
+
+fn parse_weights_from_env() -> anyhow::Result<HashMap<String, f64>> {
+  let mut weights = HashMap::new();
+
+  for (k, v) in env::vars() {
+    if let Some(feature) = k.strip_prefix("WEIGHT_") {
+      let feature = feature.to_lowercase();
+      let weight = v.parse::<f64>().context(format!("weight value for {k} is outside [-1.0,1.0] ({v})"))?.clamp(-1.0, 1.0);
+
+      if weight.is_nan() {
+        return Err(anyhow::anyhow!(format!("weight value for {feature} (through {k}) is NaN")));
+      }
+
+      weights.insert(feature, weight);
+    }
+  }
+
+  Ok(weights)
 }
 
 fn parse_index_tls_verification() -> Result<EsTlsVerification, anyhow::Error> {
@@ -371,5 +393,38 @@ mod tests {
 
     assert!("bearer".parse::<WrappedEsAuthMethod>().is_err());
     assert!("encoded_api_key".parse::<WrappedEsAuthMethod>().is_err());
+  }
+
+  #[test]
+  #[serial_test::serial]
+  fn parse_weights() {
+    unsafe {
+      env::set_var("WEIGHT_POSITIVE", "0.1");
+      env::set_var("WEIGHT_NEGATIVE", "-0.7");
+      env::set_var("WEIGHT_LOWER_CLAMPED", "-2.0");
+      env::set_var("WEIGHT_HIGHER_CLAMPED", "2.0");
+    }
+
+    let weights = super::parse_weights_from_env().unwrap();
+
+    assert!(matches!(weights.get("positive"), Some(0.1)));
+    assert!(matches!(weights.get("negative"), Some(-0.7)));
+    assert!(matches!(weights.get("lower_clamped"), Some(-1.0)));
+    assert!(matches!(weights.get("higher_clamped"), Some(1.0)));
+
+    unsafe {
+      env::remove_var("WEIGHT_POSITIVE");
+      env::remove_var("WEIGHT_NEGATIVE");
+      env::remove_var("WEIGHT_LOWER_CLAMPED");
+      env::remove_var("WEIGHT_HIGHER_CLAMPED");
+
+      env::set_var("WEIGHT_NAN", "nan");
+    }
+
+    assert!(super::parse_weights_from_env().is_err());
+
+    unsafe {
+      env::remove_var("WEIGHT_NAN");
+    }
   }
 }

--- a/crates/motiva/src/api/dto.rs
+++ b/crates/motiva/src/api/dto.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, collections::HashMap};
 
 use ahash::RandomState;
 use libmotiva::prelude::*;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 use serde_inline_default::serde_inline_default;
 use validator::{Validate, ValidationError};
 
@@ -63,6 +63,7 @@ pub(super) struct MatchHit {
 
   #[serde(rename = "match")]
   pub match_: bool,
+  #[serde(serialize_with = "serialize_score")]
   pub score: f64,
 }
 
@@ -116,4 +117,11 @@ mod tests {
 
     assert!(super::validate_weights(&weights).is_ok());
   }
+}
+
+fn serialize_score<S>(score: &f64, serializer: S) -> Result<S::Ok, S::Error>
+where
+  S: Serializer,
+{
+  serializer.serialize_f64(format_score(*score))
 }

--- a/crates/motiva/src/api/dto.rs
+++ b/crates/motiva/src/api/dto.rs
@@ -1,10 +1,10 @@
-use std::collections::HashMap;
+use std::{borrow::Cow, collections::HashMap};
 
 use ahash::RandomState;
 use libmotiva::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_inline_default::serde_inline_default;
-use validator::Validate;
+use validator::{Validate, ValidationError};
 
 #[serde_inline_default]
 #[derive(Clone, Debug, Deserialize)]
@@ -17,6 +17,9 @@ pub struct GetEntityParams {
 pub(crate) struct Payload {
   #[validate(nested, length(min = 1, message = "at least one query must be provided"))]
   pub queries: HashMap<String, SearchEntity, RandomState>,
+  #[serde(default)]
+  #[validate(custom(function = "validate_weights"))]
+  pub weights: HashMap<String, f64>,
 
   // Some query parameters are duplicated in the request body to overcome URL size limitations
   #[serde(default, skip_serializing)]
@@ -79,4 +82,38 @@ pub struct AlgorithmDescription {
 pub struct Version {
   pub motiva: String,
   pub index: String,
+}
+
+fn validate_weights(weights: &HashMap<String, f64>) -> Result<(), ValidationError> {
+  for (k, v) in weights {
+    if !(&-1.0..=&1.0).contains(&v) {
+      return Err(ValidationError {
+        message: Some(Cow::Owned(format!("weight value for {k} is outside [-1.0,1.0] ({v})"))),
+        code: Cow::Borrowed(""),
+        params: Default::default(),
+      });
+    }
+  }
+
+  Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use std::collections::HashMap;
+
+  #[test]
+  fn validate_weights() {
+    let mut weights = HashMap::new();
+    weights.insert("valid".into(), 0.4);
+    weights.insert("invalid".into(), -1.2);
+
+    assert!(super::validate_weights(&weights).is_err());
+
+    weights.clear();
+    weights.insert("valid1".into(), 0.4);
+    weights.insert("valid2".into(), -0.7);
+
+    assert!(super::validate_weights(&weights).is_ok());
+  }
 }

--- a/crates/motiva/src/api/handlers/match_entities.rs
+++ b/crates/motiva/src/api/handlers/match_entities.rs
@@ -45,8 +45,14 @@ pub async fn match_entities<F: CatalogFetcher, P: IndexProvider + 'static>(
 
   let state = Arc::new(state);
 
+  let options = Arc::new(ScoringOptions {
+    cutoff: query.cutoff,
+    weights: state.config.weights.clone().into_iter().chain(body.weights.clone()).collect(),
+  });
+
   let tasks = body.queries.into_iter().map(|(id, entity)| {
     let mut query = query.clone();
+    let options = options.clone();
 
     if let Some(ref params) = entity.params {
       if let Some(ref datasets) = params.include_datasets {
@@ -72,10 +78,10 @@ pub async fn match_entities<F: CatalogFetcher, P: IndexProvider + 'static>(
         };
 
         let scores = match query.algorithm {
-          Algorithm::NameBased => state.motiva.score::<NameBased>(&entity, hits, query.cutoff),
-          Algorithm::NameQualified => state.motiva.score::<NameQualified>(&entity, hits, query.cutoff),
-          Algorithm::MarbleV0 => state.motiva.score::<MarbleV0>(&entity, hits, query.cutoff),
-          Algorithm::LogicV1 | Algorithm::Best => state.motiva.score::<LogicV1>(&entity, hits, query.cutoff),
+          Algorithm::NameBased => state.motiva.score::<NameBased>(&entity, hits, &options),
+          Algorithm::NameQualified => state.motiva.score::<NameQualified>(&entity, hits, &options),
+          Algorithm::MarbleV0 => state.motiva.score::<MarbleV0>(&entity, hits, &options),
+          Algorithm::LogicV1 | Algorithm::Best => state.motiva.score::<LogicV1>(&entity, hits, &options),
         };
 
         match scores {

--- a/crates/motiva/src/tests/api.rs
+++ b/crates/motiva/src/tests/api.rs
@@ -132,6 +132,10 @@ async fn api_match() {
                     "name": ["Vladimir Putin", "that guy"],
                 }
             }
+        },
+        "params": {
+            "include_datasets": ["included"],
+            "exclude_datasets": ["excluded"],
         }
     }))
     .await;

--- a/crates/motiva/src/tests/e2e/mod.rs
+++ b/crates/motiva/src/tests/e2e/mod.rs
@@ -22,11 +22,15 @@ async fn e2e() {
   let listener = TcpListener::bind("0.0.0.0:0").await.unwrap();
   let addr = listener.local_addr().unwrap();
 
+  let mut weights = HashMap::new();
+  weights.insert("identifier_mismatch".into(), -0.3);
+
   let config = Config {
     listener: Some(listener),
     request_timeout: Span::from_str("10s").unwrap(),
     enrichment_max_recursion: 2,
     enrichment_query_limit: 200,
+    weights,
     ..Default::default()
   };
 

--- a/crates/motiva/src/tests/e2e/specs/match.hurl
+++ b/crates/motiva/src/tests/e2e/specs/match.hurl
@@ -174,3 +174,78 @@ jsonpath "$.responses.test.status" == 200
 jsonpath "$.responses.test.results" count == 1
 jsonpath "$.responses.test.results[?(@.id == 'Q7747')].caption" contains "Vladimir Vladimirovich Putin"
 jsonpath "$.responses.test.results[?(@.id == 'Q7747')].score" == 1.0
+
+# Instance-wide custom weight
+
+POST http://{{baseUrl}}/match/us_sanctions?algorithm=marble-v0&threshold=0.0&cutoff=0.0
+{
+    "queries": {
+        "test": {
+            "schema": "Person",
+            "properties": {
+                "name": ["Nasser Kamel"],
+                "idNumber": ["INVALID"]
+            }
+        }
+    }
+}
+
+HTTP 200
+
+[Asserts]
+jsonpath "$.responses.test.status" == 200
+jsonpath "$.responses.test.results[?(@.id == 'NK-24PVSqqr5CmqxAyN4Tzan6')].caption" contains "Nasser Al Sheikh Ali"
+jsonpath "$.responses.test.results[?(@.id == 'NK-24PVSqqr5CmqxAyN4Tzan6')].score" == 0.6
+jsonpath "$.responses.test.results[?(@.id == 'NK-24PVSqqr5CmqxAyN4Tzan6')].features.identifier_mismatch" == 1.0
+
+# Query-level custom weights
+
+POST http://{{baseUrl}}/match/us_sanctions?algorithm=marble-v0&threshold=0.0&cutoff=0.0
+{
+    "weights": {
+        "identifier_mismatch": -0.2
+    },
+    "queries": {
+        "test": {
+            "schema": "Person",
+            "properties": {
+                "name": ["Nasser Kamel"],
+                "idNumber": ["INVALID"]
+            }
+        }
+    }
+}
+
+HTTP 200
+
+[Asserts]
+jsonpath "$.responses.test.status" == 200
+jsonpath "$.responses.test.results[?(@.id == 'NK-24PVSqqr5CmqxAyN4Tzan6')].caption" contains "Nasser Al Sheikh Ali"
+jsonpath "$.responses.test.results[?(@.id == 'NK-24PVSqqr5CmqxAyN4Tzan6')].score" == 0.7
+jsonpath "$.responses.test.results[?(@.id == 'NK-24PVSqqr5CmqxAyN4Tzan6')].features.identifier_mismatch" == 1.0
+
+# Score rounding
+
+POST http://{{baseUrl}}/match/us_sanctions?algorithm=marble-v0&threshold=0.0&cutoff=0.0
+{
+    "weights": {
+        "identifier_mismatch": -0.21243
+    },
+    "queries": {
+        "test": {
+            "schema": "Person",
+            "properties": {
+                "name": ["Nasser Kamel"],
+                "idNumber": ["INVALID"]
+            }
+        }
+    }
+}
+
+HTTP 200
+
+[Asserts]
+jsonpath "$.responses.test.status" == 200
+jsonpath "$.responses.test.results[?(@.id == 'NK-24PVSqqr5CmqxAyN4Tzan6')].caption" contains "Nasser Al Sheikh Ali"
+jsonpath "$.responses.test.results[?(@.id == 'NK-24PVSqqr5CmqxAyN4Tzan6')].score" == 0.688
+jsonpath "$.responses.test.results[?(@.id == 'NK-24PVSqqr5CmqxAyN4Tzan6')].features.identifier_mismatch" == 1.0

--- a/crates/motiva/tests/motiva.rs
+++ b/crates/motiva/tests/motiva.rs
@@ -11,7 +11,8 @@ async fn scoring() {
 
   let motiva = Motiva::test(MockedElasticsearch::builder().entities(rhs).build()).build().await.unwrap();
   let rhs = motiva.search(&lhs, &MatchParams::default()).await.unwrap();
-  let scores = motiva.score::<LogicV1>(&lhs, rhs, 0.5).unwrap();
+  let options = ScoringOptions { cutoff: 0.5, ..Default::default() };
+  let scores = motiva.score::<LogicV1>(&lhs, rhs, &options).unwrap();
 
   assert_eq!(scores.len(), 2);
 


### PR DESCRIPTION
Summary

When motiva scores a candidate entity against a query, the final score is a weighted combination of individual scoring features (name similarity, identifier matches, country checks, and so on). Each feature carries a weight that determines how much it contributes to — or, for penalties, subtracts from — the overall score.

Until now those weights were fixed. This change lets you override them, either globally for the whole deployment or on a per-request basis, without changing any built-in defaults.

### How it works

- Every feature keeps its default weight. An override simply replaces that default for the named feature; any feature you don't mention keeps its default.
- Weights are clamped to the range **-1.0 to 1.0**. Negative values act as penalties, positive values as contributions.
- Setting a feature's weight to **0.0** disables it entirely — the feature is skipped during scoring, which also saves the work of computing it.
- Overrides apply across all matching algorithms (name-based, name-qualified, LogicV1/Best, and Marble V0).

### Configuration

**Global (environment variables)**

Set a weight for any feature with a `WEIGHT_<FEATURE_NAME>` variable, where the suffix is the feature's name in upper case. For example, `WEIGHT_PERSON_NAME_JARO_WINKLER=0.8`. These apply to every request the server handles. Invalid (non-numeric) values are rejected at startup, and out-of-range values are clamped into the allowed range.

**Per request**

The match request body accepts an optional `weights` object mapping feature names to weight values. This is handy for experimentation or for callers that need different tuning per query.

**Precedence**

Per-request weights take precedence over the globally configured environment weights, which in turn take precedence over the built-in defaults.

### Documentation

The library README now lists the `WEIGHT_<FEATURE_NAME>` environment variable alongside the other supported configuration options.