### PR TITLE
Wait until index is ready before becoming available.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,9 @@ jobs:
           name: motiva
       - uses: softprops/action-gh-release@v3
         with:
-          name: motiva ${{ github.ref_name }}
-          make_latest: true
+          name: motiva ${{ inputs.tag }}
+          make_latest: ${{ !contains(inputs.tag, '-rc.') }}
           generate_release_notes: true
+          prerelease: ${{ contains(inputs.tag, '-rc.') }}
           files: |
             motiva

--- a/crates/libmotiva/src/error.rs
+++ b/crates/libmotiva/src/error.rs
@@ -4,6 +4,8 @@ pub enum MotivaError {
   ConfigError(String),
   #[error("missing index: {0}, make sure you ran the indexer")]
   MissingIndex(String),
+  #[error("index is not ready")]
+  IndexUnavailable,
   #[error("resource not found")]
   ResourceNotFound,
   #[error("invalid schema: {0}")]

--- a/crates/libmotiva/src/index/elastic/builder.rs
+++ b/crates/libmotiva/src/index/elastic/builder.rs
@@ -1,5 +1,8 @@
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
 use crate::index::elastic::config::EsOptions;
-use crate::index::elastic::{DEFAULT_INDEX_PREFIX, SCOPED_INDEX_SUFFIX};
+use crate::index::elastic::{DEFAULT_INDEX_PREFIX, IndexState, SCOPED_INDEX_SUFFIX};
 use crate::{error::MotivaError, index::elastic::config::IndexVersion, prelude::ElasticsearchProvider};
 use anyhow::Context;
 use elasticsearch::cert::{Certificate, CertificateValidation};
@@ -36,24 +39,24 @@ impl ElasticsearchProvider {
 
     let index_prefix = options.index_name.unwrap_or_else(|| DEFAULT_INDEX_PREFIX.to_string());
 
-    let mut provider = ElasticsearchProvider {
+    let provider = ElasticsearchProvider {
       es,
       index_prefix: index_prefix.clone(),
-      index_version: IndexVersion::V4,
       main_index: format!("{}-entities", index_prefix),
-      scoped_index: None,
+      state: Arc::new(RwLock::new(IndexState {
+        ready: false,
+        index_version: IndexVersion::V4,
+        scoped_index: None,
+      })),
     };
 
-    if options.index_version.is_none() {
-      provider.index_version = provider.detect_index_version().await?;
-    }
-
-    provider.detect_index().await;
+    let _ = tokio::time::timeout(Duration::from_secs(5), provider.refresh_index_state()).await;
 
     Ok(provider)
   }
 
-  async fn detect_index(&mut self) {
+  /// Detect the scoped-entities alias, returning its name if it exists.
+  pub(crate) async fn detect_scoped_index(&self) -> Option<String> {
     let alias = self
       .es
       .indices()
@@ -63,9 +66,7 @@ impl ElasticsearchProvider {
       .map(|resp| resp.status_code())
       .unwrap_or(StatusCode::NOT_FOUND);
 
-    if alias == StatusCode::OK {
-      self.scoped_index = Some(self.scoped_alias_name());
-    }
+    (alias == StatusCode::OK).then(|| self.scoped_alias_name())
   }
 
   pub fn scoped_alias_name(&self) -> String {
@@ -109,10 +110,12 @@ impl Default for &EsTlsVerification {
 
 #[cfg(test)]
 mod tests {
+  use std::sync::{Arc, RwLock};
+
   use crate::index::elastic::builder::EsTlsVerification;
   use crate::index::elastic::config::EsOptions;
   use crate::{
-    index::elastic::config::IndexVersion,
+    index::elastic::{IndexState, config::IndexVersion},
     prelude::{ElasticsearchProvider, EsAuthMethod},
   };
   use elasticsearch::Elasticsearch;
@@ -122,21 +125,12 @@ mod tests {
     let (u, p) = ("secret".to_string(), "secret".to_string());
     let cert = "-----BEGIN CERTIFICATE-----\nMFAwRgIBADADBgEAMAAwHhcNNTAwMTAxMDAwMDAwWhcNNDkxMjMxMjM1OTU5WjAAMBgwCwYJKoZIhvcNAQEBAwkAMAYCAQACAQAwAwYBAAMBAA==\n-----END CERTIFICATE-----";
 
-    ElasticsearchProvider::new(
-      "http://url:9200",
-      EsOptions {
-        index_version: Some(IndexVersion::V4),
-        ..Default::default()
-      },
-    )
-    .await
-    .unwrap();
+    ElasticsearchProvider::new("http://url:9200", EsOptions { ..Default::default() }).await.unwrap();
 
     ElasticsearchProvider::new(
       "http://url:9200",
       EsOptions {
         auth: EsAuthMethod::Basic(u.clone(), p.clone()),
-        index_version: Some(IndexVersion::V4),
         ..Default::default()
       },
     )
@@ -147,7 +141,6 @@ mod tests {
       "http://url:9200",
       EsOptions {
         auth: EsAuthMethod::Bearer(p.clone()),
-        index_version: Some(IndexVersion::V4),
         ..Default::default()
       },
     )
@@ -158,7 +151,6 @@ mod tests {
       "http://url:9200",
       EsOptions {
         auth: EsAuthMethod::ApiKey(u.clone(), p.clone()),
-        index_version: Some(IndexVersion::V4),
         ..Default::default()
       },
     )
@@ -169,7 +161,6 @@ mod tests {
       "http://url:9200",
       EsOptions {
         auth: EsAuthMethod::EncodedApiKey(p.clone()),
-        index_version: Some(IndexVersion::V4),
         ..Default::default()
       },
     )
@@ -181,7 +172,6 @@ mod tests {
       EsOptions {
         auth: EsAuthMethod::Basic(u.clone(), p.clone()),
         tls: &EsTlsVerification::SkipVerify,
-        index_version: Some(IndexVersion::V4),
         ..Default::default()
       },
     )
@@ -193,7 +183,6 @@ mod tests {
       EsOptions {
         auth: EsAuthMethod::Basic(u.clone(), p.clone()),
         tls: &EsTlsVerification::CaCertChain(cert.as_bytes().to_vec()),
-        index_version: Some(IndexVersion::V4),
         ..Default::default()
       },
     )
@@ -203,19 +192,11 @@ mod tests {
 
   #[tokio::test]
   async fn es_builder_default_index_name() {
-    let provider = ElasticsearchProvider::new(
-      "http://url:9200",
-      EsOptions {
-        index_version: Some(IndexVersion::V4),
-        ..Default::default()
-      },
-    )
-    .await
-    .unwrap();
+    let provider = ElasticsearchProvider::new("http://url:9200", EsOptions { ..Default::default() }).await.unwrap();
 
     assert_eq!(provider.index_prefix, "yente");
     assert_eq!(provider.main_index, "yente-entities");
-    assert_eq!(provider.scoped_index, None);
+    assert_eq!(provider.state.read().unwrap().scoped_index, None);
   }
 
   #[tokio::test]
@@ -224,7 +205,6 @@ mod tests {
       "http://url:9200",
       EsOptions {
         index_name: Some("custom".to_string()),
-        index_version: Some(IndexVersion::V4),
         ..Default::default()
       },
     )
@@ -233,18 +213,25 @@ mod tests {
 
     assert_eq!(provider.index_prefix, "custom");
     assert_eq!(provider.main_index, "custom-entities");
-    assert_eq!(provider.scoped_index, None);
+    assert_eq!(provider.state.read().unwrap().scoped_index, None);
+  }
+
+  fn provider_with_prefix(prefix: &str) -> ElasticsearchProvider {
+    ElasticsearchProvider {
+      es: Elasticsearch::default(),
+      index_prefix: prefix.to_string(),
+      main_index: format!("{prefix}-entities"),
+      state: Arc::new(RwLock::new(IndexState {
+        ready: false,
+        index_version: IndexVersion::V4,
+        scoped_index: None,
+      })),
+    }
   }
 
   #[test]
   fn alias_names_use_prefix() {
-    let provider = ElasticsearchProvider {
-      es: Elasticsearch::default(),
-      index_version: IndexVersion::V4,
-      index_prefix: "mydata".to_string(),
-      main_index: "mydata-entities".to_string(),
-      scoped_index: None,
-    };
+    let provider = provider_with_prefix("mydata");
 
     assert_eq!(provider.main_index, "mydata-entities");
     assert_eq!(provider.scoped_alias_name(), "mydata-motiva-scoped-entities");
@@ -252,13 +239,7 @@ mod tests {
 
   #[test]
   fn alias_names_default_prefix() {
-    let provider = ElasticsearchProvider {
-      es: Elasticsearch::default(),
-      index_version: IndexVersion::V4,
-      index_prefix: "yente".to_string(),
-      main_index: "yente-entities".to_string(),
-      scoped_index: None,
-    };
+    let provider = provider_with_prefix("yente");
 
     assert_eq!(provider.main_index, "yente-entities");
     assert_eq!(provider.scoped_alias_name(), "yente-motiva-scoped-entities");

--- a/crates/libmotiva/src/index/elastic/config.rs
+++ b/crates/libmotiva/src/index/elastic/config.rs
@@ -1,17 +1,16 @@
-use std::fmt::Display;
+use std::{fmt::Display, sync::PoisonError};
 
 use ahash::HashMap;
 use elasticsearch::indices::IndicesGetMappingParts;
 use reqwest::StatusCode;
 use serde::Deserialize;
 
-use crate::{ElasticsearchProvider, EsAuthMethod, EsTlsVerification, MotivaError};
+use crate::{ElasticsearchProvider, EsAuthMethod, EsTlsVerification, MotivaError, index::IndexProvider};
 
 #[derive(Default)]
 pub struct EsOptions<'o> {
   pub auth: EsAuthMethod,
   pub tls: &'o EsTlsVerification,
-  pub index_version: Option<IndexVersion>,
   pub index_name: Option<String>,
 }
 
@@ -51,6 +50,37 @@ pub(crate) struct MappingIndexSource {
 }
 
 impl ElasticsearchProvider {
+  pub(crate) async fn refresh_index_state(&self) {
+    let (ready, version, scoped_index) = match self.detect_index_version().await {
+      Ok(version) => {
+        let healthy = self.health().await.unwrap_or(false);
+        let scoped_index = if healthy { self.detect_scoped_index().await } else { None };
+
+        (healthy, version, scoped_index)
+      }
+
+      Err(err) => {
+        tracing::warn!(error = err.to_string(), index = self.main_index, "index is not ready");
+
+        (false, self.index_version(), None)
+      }
+    };
+
+    {
+      let mut state = self.state.write().unwrap_or_else(PoisonError::into_inner);
+
+      let recovered = ready && !state.ready;
+
+      state.ready = ready;
+      state.index_version = version;
+      state.scoped_index = scoped_index;
+
+      if recovered {
+        tracing::info!(version = %version, index = self.main_index, "index is now ready");
+      }
+    }
+  }
+
   pub(crate) async fn detect_index_version(&self) -> Result<IndexVersion, MotivaError> {
     let mappings = self.es.indices().get_mapping(IndicesGetMappingParts::Index(&[&self.main_index])).send().await?;
 
@@ -62,7 +92,7 @@ impl ElasticsearchProvider {
 
     for (_, index) in mappings {
       if index.mappings.source.excludes.contains(&"name_symbols".to_string()) {
-        tracing::info!(version = ?IndexVersion::V4, "detected indexed version");
+        tracing::info!(version = ?IndexVersion::V5, "detected indexed version");
         return Ok(IndexVersion::V5);
       }
       if index.mappings.source.excludes.contains(&"name_keys".to_string()) {
@@ -71,9 +101,7 @@ impl ElasticsearchProvider {
       }
     }
 
-    tracing::warn!(version = ?IndexVersion::V4, "could not definitely determine index version, falling back");
-
-    Ok(IndexVersion::V4)
+    Err(MotivaError::OtherError(anyhow::anyhow!("index {} has an unrecognized mapping", self.main_index)))
   }
 }
 
@@ -87,10 +115,13 @@ mod tests {
     },
   };
   use serde_json::json;
-  use wiremock::{Mock, MockServer, ResponseTemplate, matchers::method};
+  use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{method, path},
+  };
 
   use super::IndexVersion;
-  use crate::{ElasticsearchProvider, MotivaError};
+  use crate::{ElasticsearchProvider, MotivaError, index::IndexProvider};
 
   #[test]
   fn index_version_display() {
@@ -99,15 +130,22 @@ mod tests {
   }
 
   fn provider(server: &MockServer) -> ElasticsearchProvider {
+    use std::sync::{Arc, RwLock};
+
+    use crate::index::elastic::IndexState;
+
     let url = Url::parse(&server.uri()).unwrap();
     let transport = TransportBuilder::new(SingleNodeConnectionPool::new(url)).build().unwrap();
 
     ElasticsearchProvider {
       es: Elasticsearch::new(transport),
-      index_version: IndexVersion::V4,
       index_prefix: "yente".to_string(),
       main_index: "yente-entities".to_string(),
-      scoped_index: None,
+      state: Arc::new(RwLock::new(IndexState {
+        ready: false,
+        index_version: IndexVersion::V4,
+        scoped_index: None,
+      })),
     }
   }
 
@@ -141,8 +179,8 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn detect_index_version_fallback() {
-    assert_eq!(detect_with_excludes("something_else").await.unwrap(), IndexVersion::V4);
+  async fn detect_index_version_unrecognized() {
+    assert!(detect_with_excludes("something_else").await.is_err());
   }
 
   #[tokio::test]
@@ -154,5 +192,83 @@ mod tests {
     let error = provider(&server).detect_index_version().await.unwrap_err();
 
     assert!(matches!(error, MotivaError::MissingIndex(_)));
+  }
+
+  #[tokio::test]
+  async fn refresh_index_state_ready() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+      .and(path("/yente-entities/_mapping"))
+      .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+          "yente-entities": { "mappings": { "_source": { "excludes": ["name_keys"] } } }
+      })))
+      .mount(&server)
+      .await;
+
+    Mock::given(method("GET"))
+      .and(path("/_cluster/health/yente-entities"))
+      .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "status": "yellow" })))
+      .mount(&server)
+      .await;
+
+    let provider = provider(&server);
+    provider.refresh_index_state().await;
+
+    assert!(provider.ready());
+    assert_eq!(provider.index_version(), IndexVersion::V4);
+    assert_eq!(provider.state.read().unwrap().scoped_index, None);
+  }
+
+  #[tokio::test]
+  async fn refresh_index_state_ready_with_scoped_index() {
+    let server = MockServer::start().await;
+
+    // Recognized mapping (V5), healthy cluster, and a scoped index
+    Mock::given(method("GET"))
+      .and(path("/yente-entities/_mapping"))
+      .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+          "yente-entities": { "mappings": { "_source": { "excludes": ["name_symbols"] } } }
+      })))
+      .mount(&server)
+      .await;
+
+    Mock::given(method("GET"))
+      .and(path("/_cluster/health/yente-entities"))
+      .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "status": "green" })))
+      .mount(&server)
+      .await;
+
+    Mock::given(method("GET"))
+      .and(path("/yente-motiva-scoped-entities/_alias"))
+      .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+      .mount(&server)
+      .await;
+
+    let provider = provider(&server);
+    provider.refresh_index_state().await;
+
+    assert!(provider.ready());
+    assert_eq!(provider.index_version(), IndexVersion::V5);
+    assert_eq!(provider.state.read().unwrap().scoped_index, Some("yente-motiva-scoped-entities".to_string()));
+  }
+
+  #[tokio::test]
+  async fn refresh_index_state_not_ready() {
+    let server = MockServer::start().await;
+
+    // Missing index: the mapping probe returns 404, so we never reach the health
+    // check and the provider stays not-ready.
+    Mock::given(method("GET"))
+      .and(path("/yente-entities/_mapping"))
+      .respond_with(ResponseTemplate::new(404))
+      .mount(&server)
+      .await;
+
+    let provider = provider(&server);
+    provider.refresh_index_state().await;
+
+    assert!(!provider.ready());
+    assert_eq!(provider.state.read().unwrap().scoped_index, None);
   }
 }

--- a/crates/libmotiva/src/index/elastic/mod.rs
+++ b/crates/libmotiva/src/index/elastic/mod.rs
@@ -3,7 +3,12 @@ pub(crate) mod config;
 pub(crate) mod queries;
 pub(crate) mod scoped;
 
-use std::{collections::HashMap, fmt::Debug};
+use std::{
+  borrow::Cow,
+  collections::HashMap,
+  fmt::Debug,
+  sync::{Arc, PoisonError, RwLock},
+};
 
 use ahash::RandomState;
 use elasticsearch::Elasticsearch;
@@ -20,23 +25,33 @@ use crate::{
 const DEFAULT_INDEX_PREFIX: &str = "yente";
 const SCOPED_INDEX_SUFFIX: &str = "motiva-scoped-entities";
 
+#[derive(Clone, Debug)]
+pub(crate) struct IndexState {
+  pub(crate) ready: bool,
+  pub(crate) index_version: IndexVersion,
+  pub(crate) scoped_index: Option<String>,
+}
+
 /// Main index provider using Elasticsearch
 #[derive(Clone)]
 pub struct ElasticsearchProvider {
   pub es: Elasticsearch,
-  pub(crate) index_version: IndexVersion,
   pub(crate) index_prefix: String,
   pub(crate) main_index: String,
-  pub(crate) scoped_index: Option<String>,
+  pub(crate) state: Arc<RwLock<IndexState>>,
 }
 
 impl ElasticsearchProvider {
   #[inline]
-  pub fn index_name(&self, kind: IndexType) -> &str {
-    match (kind, &self.scoped_index) {
-      (IndexType::Main, _) => &self.main_index,
-      (IndexType::Scoped, None) => &self.main_index,
-      (IndexType::Scoped, Some(scoped_index)) => scoped_index,
+  pub fn index_name(&self, kind: IndexType) -> Cow<'_, str> {
+    let scoped_index = match kind {
+      IndexType::Main => None,
+      IndexType::Scoped => self.state.read().unwrap_or_else(PoisonError::into_inner).scoped_index.clone(),
+    };
+
+    match scoped_index {
+      Some(scoped_index) => Cow::Owned(scoped_index),
+      None => Cow::Borrowed(&self.main_index),
     }
   }
 }
@@ -196,18 +211,25 @@ mod tests {
 
   #[test]
   fn build_index_name() {
-    let mut p = ElasticsearchProvider {
+    use std::sync::{Arc, RwLock};
+
+    use crate::index::elastic::IndexState;
+
+    let p = ElasticsearchProvider {
       es: Elasticsearch::default(),
-      index_version: IndexVersion::V5,
       index_prefix: "myprefix".to_string(),
       main_index: "myprefix-entities".to_string(),
-      scoped_index: None,
+      state: Arc::new(RwLock::new(IndexState {
+        ready: true,
+        index_version: IndexVersion::V5,
+        scoped_index: None,
+      })),
     };
 
     assert_eq!(p.index_name(IndexType::Main), "myprefix-entities");
     assert_eq!(p.index_name(IndexType::Scoped), "myprefix-entities");
 
-    p.scoped_index = Some("myprefix-motiva-scoped-entities".to_string());
+    p.state.write().unwrap().scoped_index = Some("myprefix-motiva-scoped-entities".to_string());
 
     assert_eq!(p.index_name(IndexType::Main), "myprefix-entities");
     assert_eq!(p.index_name(IndexType::Scoped), "myprefix-motiva-scoped-entities");

--- a/crates/libmotiva/src/index/elastic/queries.rs
+++ b/crates/libmotiva/src/index/elastic/queries.rs
@@ -1,6 +1,6 @@
 use std::{
   collections::{HashMap, HashSet},
-  sync::Arc,
+  sync::{Arc, PoisonError},
 };
 
 use ahash::RandomState;
@@ -32,11 +32,21 @@ use crate::{
 
 impl IndexProvider for ElasticsearchProvider {
   fn after_init(&self) {
-    tracing::info!(version = ?self.index_version, scoped_index = self.scoped_index, main_index = self.main_index, "detected yente version and index name");
+    let state = self.state.read().unwrap_or_else(PoisonError::into_inner);
+
+    tracing::info!(version = ?state.index_version, scoped_index = ?state.scoped_index, main_index = self.main_index, ready = state.ready, "detected yente version and index name");
   }
 
   fn index_version(&self) -> IndexVersion {
-    self.index_version
+    self.state.read().unwrap_or_else(PoisonError::into_inner).index_version
+  }
+
+  fn ready(&self) -> bool {
+    self.state.read().unwrap_or_else(PoisonError::into_inner).ready
+  }
+
+  async fn refresh(&self) {
+    self.refresh_index_state().await;
   }
 
   /// Whether the Elasticsearch cluster is up and healthy.
@@ -68,13 +78,19 @@ impl IndexProvider for ElasticsearchProvider {
   /// Search for candidate entities matching input parameters.
   #[instrument(skip_all)]
   async fn search(&self, catalog: &Arc<RwLock<Catalog>>, entity: &SearchEntity, params: &MatchParams) -> Result<Vec<Entity>, MotivaError> {
-    let query = build_query(catalog, self.index_version, self.index_name(params.index_type), entity, params).await?;
+    if !self.ready() {
+      return Err(MotivaError::IndexUnavailable);
+    }
+
+    let index_version = self.index_version();
+    let index_name = self.index_name(params.index_type);
+    let query = build_query(catalog, index_version, &index_name, entity, params).await?;
 
     tracing::trace!(%query, "running query");
 
     let response = self
       .es
-      .search(SearchParts::Index(&[self.index_name(params.index_type)]))
+      .search(SearchParts::Index(&[index_name.as_ref()]))
       .from(0)
       .size(params.candidate_limit(params.match_candidates) as i64)
       .search_type(SearchType::DfsQueryThenFetch)
@@ -114,6 +130,10 @@ impl IndexProvider for ElasticsearchProvider {
   /// with their IDs, and not their actual data.
   #[instrument(skip_all)]
   async fn get_entity(&self, id: &str) -> Result<EntityHandle, MotivaError> {
+    if !self.ready() {
+      return Err(MotivaError::IndexUnavailable);
+    }
+
     let query = json!({
       "query": {
           "bool": {
@@ -162,6 +182,10 @@ impl IndexProvider for ElasticsearchProvider {
   /// Get entities related to an entity.
   #[instrument(skip_all)]
   async fn get_related_entities(&self, root: Option<&String>, values: &[String], negatives: &HashSet<String, RandomState>, limit: usize) -> Result<Vec<Entity>, MotivaError> {
+    if !self.ready() {
+      return Err(MotivaError::IndexUnavailable);
+    }
+
     let mut shoulds = vec![json!({ "ids": { "values": values } })];
 
     if let Some(root) = root {
@@ -217,6 +241,9 @@ impl IndexProvider for ElasticsearchProvider {
     )
   }
 
+  // Unlike the query methods, this is intentionally not gated on `ready()`: it
+  // is what catalog build and readiness recovery use to probe the index, so it
+  // must keep working while the provider is still not ready.
   async fn list_indices(&self) -> Result<Vec<(String, String)>, MotivaError> {
     let indices: HashMap<String, serde_json::Value> = self.es.indices().get_alias(IndicesGetAliasParts::Name(&[&self.main_index])).send().await?.json().await?;
 
@@ -224,6 +251,10 @@ impl IndexProvider for ElasticsearchProvider {
   }
 
   async fn list_field_values(&self, fields: &[&str], query: Option<serde_json::Value>) -> Result<HashMap<String, Vec<String>>, MotivaError> {
+    if !self.ready() {
+      return Err(MotivaError::IndexUnavailable);
+    }
+
     let mut aggs = HashMap::<String, serde_json::Value>::default();
 
     for field in fields {
@@ -915,5 +946,34 @@ mod tests {
       HashSet::<(String, String)>::from_iter(versions.into_iter()),
       HashSet::from_iter(vec![("dataset1".to_string(), "20250901000000-abc".to_string()), ("dataset2".to_string(), "20251127104000-xyz".to_string())].into_iter())
     );
+  }
+
+  #[tokio::test]
+  async fn queries_are_unavailable_when_not_ready() {
+    use crate::{
+      MotivaError,
+      index::{IndexProvider, elastic::IndexState},
+      prelude::ElasticsearchProvider,
+    };
+
+    let provider = ElasticsearchProvider {
+      es: elasticsearch::Elasticsearch::default(),
+      index_prefix: "yente".to_string(),
+      main_index: "yente-entities".to_string(),
+      state: Arc::new(std::sync::RwLock::new(IndexState {
+        ready: false,
+        index_version: IndexVersion::V4,
+        scoped_index: None,
+      })),
+    };
+
+    let catalog = fake_catalog();
+    let entity = SearchEntity::builder("Person").properties(&[("name", &["x"])]).build();
+    let negatives = HashSet::<String, ahash::RandomState>::default();
+
+    assert!(matches!(provider.search(&catalog, &entity, &MatchParams::default()).await, Err(MotivaError::IndexUnavailable)));
+    assert!(matches!(provider.get_entity("id").await, Err(MotivaError::IndexUnavailable)));
+    assert!(matches!(provider.get_related_entities(None, &[], &negatives, 10).await, Err(MotivaError::IndexUnavailable)));
+    assert!(matches!(provider.list_field_values(&["schema"], None).await, Err(MotivaError::IndexUnavailable)));
   }
 }

--- a/crates/libmotiva/src/index/mock.rs
+++ b/crates/libmotiva/src/index/mock.rs
@@ -20,6 +20,9 @@ use crate::{
 #[derive(Clone, Builder, Default)]
 pub struct MockedElasticsearch {
   healthy: Option<bool>,
+  ready: Option<bool>,
+  indexing_done: Option<bool>,
+
   #[builder(default)]
   entities: Vec<Entity>,
   entity: Option<EntityHandle>,
@@ -32,6 +35,10 @@ pub struct MockedElasticsearch {
 impl IndexProvider for MockedElasticsearch {
   fn index_version(&self) -> IndexVersion {
     IndexVersion::V4
+  }
+
+  fn ready(&self) -> bool {
+    self.ready.unwrap_or(true)
   }
 
   async fn health(&self) -> Result<bool, MotivaError> {
@@ -65,6 +72,10 @@ impl IndexProvider for MockedElasticsearch {
   }
 
   async fn list_indices(&self) -> Result<Vec<(String, String)>, MotivaError> {
+    if !self.indexing_done.unwrap_or(true) {
+      return Err(MotivaError::OtherError(anyhow::anyhow!("indexing is not done")));
+    }
+
     Ok(self.indices.clone())
   }
 

--- a/crates/libmotiva/src/index/mod.rs
+++ b/crates/libmotiva/src/index/mod.rs
@@ -21,6 +21,14 @@ use crate::{
 pub trait IndexProvider: Clone + Send + Sync + 'static {
   fn after_init(&self) {}
 
+  fn ready(&self) -> bool {
+    true
+  }
+
+  fn refresh(&self) -> impl Future<Output = ()> + Send {
+    async {}
+  }
+
   fn index_version(&self) -> IndexVersion;
   fn health(&self) -> impl Future<Output = Result<bool, MotivaError>> + Send;
   fn get_entity(&self, id: &str) -> impl Future<Output = Result<EntityHandle, MotivaError>> + Send;

--- a/crates/libmotiva/src/motiva.rs
+++ b/crates/libmotiva/src/motiva.rs
@@ -1,6 +1,5 @@
 use std::{collections::HashMap, sync::Arc};
 
-use anyhow::Context;
 use bon::bon;
 use jiff::Span;
 use tokio::sync::RwLock;
@@ -90,6 +89,24 @@ pub struct Motiva<P: IndexProvider, F: CatalogFetcher = HttpCatalogFetcher> {
   catalog: Arc<RwLock<Catalog>>,
 }
 
+/// Perform the initial catalog fetch, tolerating failures.
+///
+/// If the catalog cannot be built (e.g. the index is missing or upstream is
+/// unreachable), we start with an empty catalog and log a warning rather than
+/// aborting startup. The background refresh loop recovers it once the index and
+/// upstream become available.
+async fn init_catalog<P: IndexProvider, F: CatalogFetcher>(fetcher: &F, provider: &P, outdated_grace: Span) -> Catalog {
+  match get_merged_catalog(fetcher, provider, outdated_grace).await {
+    Ok(catalog) => catalog,
+
+    Err(err) => {
+      tracing::warn!(error = err.to_string(), "could not initialize catalog, starting with an empty catalog");
+
+      Catalog::default()
+    }
+  }
+}
+
 #[bon]
 impl<P: IndexProvider> Motiva<P> {
   /// Create a new Motiva instance.
@@ -115,7 +132,7 @@ impl<P: IndexProvider> Motiva<P> {
     provider.after_init();
 
     let fetcher = HttpCatalogFetcher::default();
-    let catalog = get_merged_catalog(&fetcher, &provider, config.outdated_grace).await.context("could not initialize manifest")?;
+    let catalog = init_catalog(&fetcher, &provider, config.outdated_grace).await;
 
     Ok(Motiva {
       config,
@@ -131,7 +148,7 @@ impl<P: IndexProvider> Motiva<P> {
 
     provider.after_init();
 
-    let catalog = get_merged_catalog(&fetcher, &provider, config.outdated_grace).await.context("could not initialize manifest")?;
+    let catalog = init_catalog(&fetcher, &provider, config.outdated_grace).await;
 
     Ok(Motiva {
       config,
@@ -152,7 +169,7 @@ impl<P: IndexProvider> Motiva<P, TestFetcher> {
   ) -> Result<Motiva<P, TestFetcher>, MotivaError> {
     crate::init();
 
-    let catalog = get_merged_catalog(&fetcher, &provider, config.outdated_grace).await.context("could not initialize manifest")?;
+    let catalog = init_catalog(&fetcher, &provider, config.outdated_grace).await;
 
     Ok(Motiva::<P, _> {
       config,
@@ -171,6 +188,23 @@ impl<P: IndexProvider, F: CatalogFetcher> Motiva<P, F> {
   /// index is available and ready to be queried.
   pub async fn health(&self) -> Result<bool, MotivaError> {
     self.index.health().await
+  }
+
+  /// Whether the backing index is ready to serve queries.
+  ///
+  /// This reflects the latest background readiness check performed by the
+  /// [`IndexProvider`]. When `false`, callers should surface an unavailable
+  /// status rather than attempting to query.
+  pub fn ready(&self) -> bool {
+    self.index.ready()
+  }
+
+  /// Re-check the backing index and update its cached readiness state.
+  ///
+  /// Meant to be called periodically from a background task so the index can
+  /// recover once it becomes available.
+  pub async fn refresh(&self) {
+    self.index.refresh().await;
   }
 
   /// Get the detected index version.
@@ -240,7 +274,11 @@ impl<P: IndexProvider, F: CatalogFetcher> Motiva<P, F> {
   /// By default, returns the cached merged dataset from the latest pull.
   /// If `force_refresh` is set to `true`, will perform a synchronous
   /// synchronization and merge from upstream.
-  pub async fn get_catalog(&self, force_refresh: bool) -> anyhow::Result<Catalog> {
+  pub async fn get_catalog(&self, force_refresh: bool) -> Result<Catalog, MotivaError> {
+    if !self.ready() {
+      return Err(MotivaError::IndexUnavailable);
+    }
+
     if force_refresh {
       self.refresh_catalog().await;
     }
@@ -299,5 +337,28 @@ mod tests {
     assert!(initial_catalog.datasets.iter().find(|ds| ds.name == "dataset1").is_some());
 
     motiva.refresh_catalog().await;
+  }
+
+  #[tokio::test]
+  async fn ready_and_refresh_passthrough() {
+    let index = MockedElasticsearch::builder().ready(false).build();
+    let motiva = Motiva::test(index).build().await.unwrap();
+
+    assert!(!motiva.ready());
+    motiva.refresh().await;
+    assert!(!motiva.ready());
+
+    let index = MockedElasticsearch::builder().ready(true).build();
+    let motiva = Motiva::test(index).build().await.unwrap();
+
+    assert!(motiva.ready());
+  }
+
+  #[tokio::test]
+  async fn build_tolerates_failing_catalog() {
+    let index = MockedElasticsearch::builder().indexing_done(false).build();
+    let motiva = Motiva::test(index).build().await.unwrap();
+
+    assert!(motiva.get_catalog(false).await.unwrap().datasets.is_empty());
   }
 }

--- a/crates/motiva/src/api/errors.rs
+++ b/crates/motiva/src/api/errors.rs
@@ -22,6 +22,8 @@ pub enum AppError {
   ResourceNotFound,
   #[error("server error, please check your logs for more information")]
   ServerError,
+  #[error("the index is not ready, please try again later")]
+  ServiceUnavailable,
   #[error(transparent)]
   OtherError(#[from] anyhow::Error),
 
@@ -39,6 +41,7 @@ impl From<MotivaError> for AppError {
     match value {
       MotivaError::ConfigError(err) => AppError::ConfigError(err),
       MotivaError::MissingIndex(_) => AppError::ServerError,
+      MotivaError::IndexUnavailable => AppError::ServiceUnavailable,
       MotivaError::IndexError(err) => AppError::IndexError(err.to_string()),
       MotivaError::InvalidSchema(_) => AppError::BadRequest,
       MotivaError::ResourceNotFound => AppError::ResourceNotFound,
@@ -61,6 +64,7 @@ impl From<&AppError> for ApiError {
       AppError::BadRequest => ApiError(StatusCode::BAD_REQUEST, value.to_string(), None),
       AppError::InvalidCredentials => ApiError(StatusCode::UNAUTHORIZED, value.to_string(), None),
       AppError::ResourceNotFound => ApiError(StatusCode::NOT_FOUND, value.to_string(), None),
+      AppError::ServiceUnavailable => ApiError(StatusCode::SERVICE_UNAVAILABLE, value.to_string(), None),
       AppError::IndexError(_) => ApiError(StatusCode::INTERNAL_SERVER_ERROR, value.to_string(), None),
       AppError::InvalidQuery(err) => ApiError(StatusCode::BAD_REQUEST, value.to_string(), Some(vec![err.to_string()])),
       AppError::OtherError(inner) if inner.is::<AppError>() => match inner.downcast_ref::<AppError>() {
@@ -120,6 +124,7 @@ mod tests {
         "error from indexer: index error",
       ),
       (MotivaError::InvalidSchema("invalid schema".into()), StatusCode::BAD_REQUEST, "bad request"),
+      (MotivaError::IndexUnavailable, StatusCode::SERVICE_UNAVAILABLE, "the index is not ready, please try again later"),
       (MotivaError::OtherError(anyhow::anyhow!("any error")), StatusCode::INTERNAL_SERVER_ERROR, "any error"),
     ];
 
@@ -156,6 +161,7 @@ mod tests {
       (AppError::IndexError("index error".into()), StatusCode::INTERNAL_SERVER_ERROR, "error from indexer: index error"),
       (AppError::ConfigError("config error".into()), StatusCode::INTERNAL_SERVER_ERROR, "invalid configuration: config error"),
       (AppError::ServerError, StatusCode::INTERNAL_SERVER_ERROR, "server error, please check your logs for more information"),
+      (AppError::ServiceUnavailable, StatusCode::SERVICE_UNAVAILABLE, "the index is not ready, please try again later"),
       (AppError::OtherError(anyhow::anyhow!("any error")), StatusCode::INTERNAL_SERVER_ERROR, "any error"),
     ];
 

--- a/crates/motiva/src/api/handlers/get_entity.rs
+++ b/crates/motiva/src/api/handlers/get_entity.rs
@@ -17,6 +17,10 @@ pub async fn get_entity<F: CatalogFetcher, P: IndexProvider>(
   Path(id): Path<String>,
   Query(params): Query<GetEntityParams>,
 ) -> Result<impl IntoResponse, AppError> {
+  if !state.motiva.ready() {
+    return Err(AppError::ServiceUnavailable);
+  }
+
   let behavior = if params.nested { GetEntityBehavior::FetchNestedEntity } else { GetEntityBehavior::RootOnly };
   let limit = GetEntityLimits::new(state.config.enrichment_max_recursion, state.config.enrichment_query_limit);
 
@@ -61,6 +65,22 @@ mod tests {
 
     assert_eq!(response.status(), StatusCode::PERMANENT_REDIRECT);
     assert_eq!(response.headers().get("location").unwrap().to_str().unwrap(), "/entities/canonical");
+  }
+
+  #[tokio::test]
+  async fn get_entity_not_ready_returns_503() {
+    let index = MockedElasticsearch::builder().ready(false).build();
+    let state = AppState {
+      config: Arc::new(Config::default()),
+      prometheus: None,
+      motiva: Motiva::test(index).fetcher(TestFetcher::default()).build().await.unwrap(),
+    };
+
+    let response = super::get_entity(State(state), Auth::noop(), Path("some-id".to_string()), Query(GetEntityParams { nested: false }))
+      .await
+      .into_response();
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
   }
 
   #[tokio::test]

--- a/crates/motiva/src/api/handlers/match_entities.rs
+++ b/crates/motiva/src/api/handlers/match_entities.rs
@@ -26,6 +26,10 @@ pub async fn match_entities<F: CatalogFetcher, P: IndexProvider + 'static>(
   Query(mut query): Query<MatchParams>,
   TypedJson(mut body): TypedJson<Payload>,
 ) -> Result<(StatusCode, impl IntoResponse), AppError> {
+  if !state.motiva.ready() {
+    return Err(AppError::ServiceUnavailable);
+  }
+
   query.scope = scope;
   query.candidate_factor = state.config.match_candidates;
 

--- a/crates/motiva/src/api/handlers/mod.rs
+++ b/crates/motiva/src/api/handlers/mod.rs
@@ -24,10 +24,10 @@ pub async fn healthz() -> StatusCode {
   StatusCode::OK
 }
 
-pub async fn readyz<F: CatalogFetcher, P: IndexProvider>(State(state): State<AppState<F, P>>) -> Result<impl IntoResponse, AppError> {
-  match state.motiva.health().await? {
-    true => Ok(StatusCode::OK),
-    false => Ok(StatusCode::SERVICE_UNAVAILABLE),
+pub async fn readyz<F: CatalogFetcher, P: IndexProvider>(State(state): State<AppState<F, P>>) -> impl IntoResponse {
+  match state.motiva.ready() {
+    true => StatusCode::OK,
+    false => StatusCode::SERVICE_UNAVAILABLE,
   }
 }
 

--- a/crates/motiva/src/api/mod.rs
+++ b/crates/motiva/src/api/mod.rs
@@ -4,6 +4,7 @@ use axum::{
   Router, middleware,
   routing::{get, post},
 };
+use jiff::ToSpan;
 use libmotiva::prelude::*;
 use metrics_exporter_prometheus::PrometheusHandle;
 use reqwest::StatusCode;
@@ -39,13 +40,23 @@ pub async fn routes<F: CatalogFetcher, P: IndexProvider>(config: Config, fetcher
 
   tokio::spawn({
     let motiva = motiva.clone();
-    let interval = config.catalog_refresh_interval.try_into().unwrap();
+    let readiness_interval = 15.seconds().try_into().unwrap();
+    let refresh_interval = config.catalog_refresh_interval.try_into().unwrap();
 
     async move {
-      loop {
-        tokio::time::sleep(interval).await;
+      while !motiva.ready() {
+        motiva.refresh().await;
 
+        if motiva.ready() {
+          break;
+        }
+
+        tokio::time::sleep(readiness_interval).await;
+      }
+
+      loop {
         motiva.refresh_catalog().await;
+        tokio::time::sleep(refresh_interval).await;
       }
     }
   });

--- a/crates/motiva/src/main.rs
+++ b/crates/motiva/src/main.rs
@@ -31,7 +31,6 @@ async fn main() -> anyhow::Result<()> {
     auth: config.index_auth_method.clone(),
     tls: &config.index_tls_verification,
     index_name: config.index_name.clone(),
-    ..Default::default()
   };
 
   let provider = ElasticsearchProvider::new(&config.index_url, options).await?;

--- a/crates/motiva/src/tests/api.rs
+++ b/crates/motiva/src/tests/api.rs
@@ -45,7 +45,7 @@ async fn api_not_version() {
 
 #[tokio::test]
 async fn api_health_unhealthy() {
-  let index = MockedElasticsearch::builder().healthy(false).build();
+  let index = MockedElasticsearch::builder().ready(false).build();
 
   let state = AppState {
     config: Arc::new(Config::default()),
@@ -173,6 +173,31 @@ async fn api_match() {
         }
       }
   }));
+}
+
+#[tokio::test]
+async fn api_match_not_ready() {
+  let index = MockedElasticsearch::builder().ready(false).build();
+
+  let state = AppState {
+    config: Arc::new(Config::default()),
+    prometheus: None,
+    motiva: Motiva::test(index).fetcher(TestFetcher::default()).build().await.unwrap(),
+  };
+
+  let app = Router::new().route("/match/{scope}", post(handlers::match_entities)).with_state(state);
+  let server = TestServer::new(app);
+
+  let response = server
+    .post("/match/default")
+    .json(&json!({
+        "queries": {
+            "test": { "schema": "Person", "properties": { "name": ["Vladimir Putin"] } }
+        }
+    }))
+    .await;
+
+  assert_eq!(response.status_code(), 503);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Until now, motiva refused to start if the index was not ready. Being ready means existing and having the right mapping for us to check the used Yente version and compute the catalog.

This commit lets motiva start and respond to /healthz while returning 503 Service Unavailable on /readyz and all endpoints using the index if it is not ready yet.

If not, a background task will check every 15 seconds if it is and make the service available when it is.