### PR TITLE
Tolerate empty queries or properties.

### DIFF
--- a/crates/libmotiva/src/model.rs
+++ b/crates/libmotiva/src/model.rs
@@ -124,7 +124,6 @@ pub struct PayloadParams {
 #[derive(Clone, Debug, Deserialize, Serialize, Validate)]
 pub struct SearchEntity {
   pub schema: Schema,
-  #[validate(length(min = 1, message = "at least one property must be given"))]
   pub properties: HashMap<String, Vec<String>, RandomState>,
 
   #[serde(default)]
@@ -202,7 +201,9 @@ impl SearchEntity {
       names
     };
 
-    self.properties.entry("alias".into()).or_default().extend(aliases);
+    if !aliases.is_empty() {
+      self.properties.entry("alias".into()).or_default().extend(aliases);
+    }
   }
 
   pub fn pick_names(&self, count: usize) -> Cow<'_, [String]> {

--- a/crates/motiva/src/api/dto.rs
+++ b/crates/motiva/src/api/dto.rs
@@ -15,7 +15,7 @@ pub struct GetEntityParams {
 
 #[derive(Clone, Debug, Deserialize, Serialize, Validate)]
 pub(crate) struct Payload {
-  #[validate(nested, length(min = 1, message = "at least one query must be provided"))]
+  #[validate(nested)]
   pub queries: HashMap<String, SearchEntity, RandomState>,
   #[serde(default)]
   #[validate(custom(function = "validate_weights"))]

--- a/crates/motiva/src/api/handlers/match_entities.rs
+++ b/crates/motiva/src/api/handlers/match_entities.rs
@@ -71,6 +71,17 @@ pub async fn match_entities<F: CatalogFetcher, P: IndexProvider + 'static>(
       let state = Arc::clone(&state);
 
       async move {
+        if entity.properties.is_empty() {
+          return (
+            id,
+            MatchResults {
+              status: 200,
+              total: Some(MatchTotal { relation: "eq", value: 0 }),
+              results: vec![],
+            },
+          );
+        }
+
         let hits = match state.motiva.search(&entity, &query).await {
           Ok(hits) => hits,
 

--- a/crates/motiva/src/tests/api.rs
+++ b/crates/motiva/src/tests/api.rs
@@ -244,32 +244,3 @@ async fn api_unparsable_payload() {
 
   assert_eq!(response.status_code(), 400);
 }
-
-#[tokio::test]
-async fn api_invalid_payload() {
-  let index = MockedElasticsearch::builder().healthy(false).build();
-
-  let state = AppState {
-    config: Arc::new(Config::default()),
-    prometheus: None,
-    motiva: Motiva::test(index).build().await.unwrap(),
-  };
-
-  let app = Router::new().route("/match/{scope}", post(handlers::match_entities)).with_state(state);
-  let server = TestServer::new(app);
-
-  let response = server
-    .post("/match/default")
-    .json(&json!({
-        "queries": {}
-    }))
-    .await;
-
-  assert_eq!(response.status_code(), 422);
-
-  response.assert_json_contains(&json!({
-      "details": [
-          "queries: at least one query must be provided"
-      ]
-  }));
-}


### PR DESCRIPTION
Some edge cases could perform queries with no properties, which would initially return a 422. We now tolerate those invalid payloads and return empty results instead.