### PR TITLE
Replace elasticsearch-rs with opensearch.

### DIFF
--- a/.github/scripts/featuresets.py
+++ b/.github/scripts/featuresets.py
@@ -1,7 +1,7 @@
 import itertools
 import json
 
-FEATURES = ["gcp"]
+FEATURES = ["gcp", "aws"]
 
 combinations: list[dict] = []
 
@@ -9,7 +9,6 @@ for i in range(len(FEATURES) + 1):
     for combo in itertools.combinations(FEATURES, i):
         features = ",".join(combo)
         suffix = ""
-        base = "native"
 
         if combo:
             suffix = "-" + "-".join(combo)
@@ -17,7 +16,6 @@ for i in range(len(FEATURES) + 1):
         combinations.append(
             {
                 "features": features,
-                "base": base,
                 "suffix": suffix,
             }
         )

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,9 +197,27 @@ jobs:
         env:
           INDEX_URL: http://localhost:9200
 
+  generate-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.generate.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+      - name: Generate feature combinations
+        id: generate
+        run: |
+          combinations=$(python .github/scripts/featuresets.py)
+          echo "matrix=$combinations" >> $GITHUB_OUTPUT
+
   build:
     runs-on: ubuntu-latest
-    needs: [check, lint]
+    needs: [check, lint, generate-matrix]
+    strategy:
+      matrix:
+        combination: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -220,22 +238,28 @@ jobs:
             ~/.cargo/bin
             ~/.cargo/registry
             ~/.cargo/git
-          key: "build-${{ github.job }}-${{hashFiles('Cargo.lock', 'pyproject.toml')}}"
+          key: "build-${{ github.job }}${{ matrix.combination.suffix }}-${{hashFiles('Cargo.lock', 'pyproject.toml')}}"
           restore-keys: |
+            build-${{ github.job }}${{ matrix.combination.suffix }}-
             build-${{ github.job }}-
             build-
             check-${{ github.job }}-
             check-
 
       - name: Build
-        run: cargo build --locked --release --all-features
+        run: cargo build --locked --release ${{ matrix.combination.features != '' && format('--features {0}', matrix.combination.features) || '' }}
 
       - name: Print version
-        run: cargo run --release --all-features -- version
+        run: cargo run --release ${{ matrix.combination.features != '' && format('--features {0}', matrix.combination.features) || '' }} -- version
+
+      - name: Stage binary
+        run: |
+          mkdir -p dist
+          cp target/release/motiva dist/motiva${{ matrix.combination.suffix }}
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v7
         with:
-          name: motiva
-          path: target/release/motiva
+          name: motiva${{ matrix.combination.suffix }}
+          path: dist/motiva${{ matrix.combination.suffix }}
           retention-days: 7

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
       - name: Generate feature combinations
         id: generate
         run: |
@@ -80,7 +82,6 @@ jobs:
             apognu/motiva:${{ inputs.tag }}${{ matrix.combination.suffix }}
             ghcr.io/apognu/motiva:${{ inputs.tag }}${{ matrix.combination.suffix }}
           build-args: |
-            "BASE=${{ matrix.combination.base }}"
             ${{ matrix.combination.features != '' && format('CARGO_ARGS=--features {0}', matrix.combination.features) || '' }}
           push: true
           provenance: mode=max
@@ -102,4 +103,3 @@ jobs:
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
           create-storage-record: false
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,16 @@ jobs:
     env:
       PRERELEASE: ${{ contains(inputs.tag, '-rc.') }}
     steps:
-      - name: Download artifact
+      - name: Download artifacts
         uses: actions/download-artifact@v8
         with:
-          name: motiva
+          pattern: motiva*
+          merge-multiple: true
 
       - name: Attest
         uses: actions/attest@v4
         with:
-          subject-path: ${{ github.workspace }}/motiva
+          subject-path: ${{ github.workspace }}/motiva*
 
       - name: Create release
         uses: softprops/action-gh-release@v3
@@ -36,8 +37,7 @@ jobs:
           make_latest: ${{ env.PRERELEASE == 'false' }}
           draft: ${{ env.PRERELEASE == 'true' }}
           prerelease: ${{ env.PRERELEASE == 'true' }}
-          files: |
-            motiva
+          files: motiva*
 
       - name: Publish prerelease
         uses: softprops/action-gh-release@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2822,6 +2822,9 @@ dependencies = [
  "any_ascii",
  "anyhow",
  "aws-config",
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-runtime-api",
  "bon",
  "bumpalo",
  "celes",
@@ -2852,6 +2855,7 @@ dependencies = [
  "shellexpand",
  "std-macro-extensions",
  "strsim 0.11.1",
+ "temp-env",
  "thiserror",
  "tokio",
  "tokio-test",
@@ -3132,6 +3136,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "shadow-rs",
+ "temp-env",
  "thiserror",
  "tokio",
  "tower-http 0.7.0",
@@ -4969,6 +4974,16 @@ name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "futures",
+ "parking_lot",
+]
 
 [[package]]
 name = "tempfile"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,29 +1143,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
-name = "elasticsearch"
-version = "9.1.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bb303aa6e1d28c0c86b6fbfe484fd0fd3f512629aeed1ac4f6b85f81d9834a"
-dependencies = [
- "base64",
- "bytes",
- "dyn-clone",
- "flate2",
- "lazy_static",
- "parking_lot",
- "percent-encoding",
- "reqwest 0.12.28",
- "rustc_version",
- "serde",
- "serde_json",
- "serde_with",
- "tokio",
- "url",
- "void",
-]
-
-[[package]]
 name = "email_address"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1466,7 +1449,7 @@ dependencies = [
  "once_cell",
  "prost",
  "prost-types",
- "reqwest 0.13.4",
+ "reqwest",
  "secret-vault-value",
  "serde",
  "serde_json",
@@ -1487,7 +1470,7 @@ checksum = "26d27dbcc645b60b8e7f6e2868a9d7102ece97d1bb49c1288b5321fcc67f7260"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "http",
@@ -1666,7 +1649,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
  "http",
@@ -1759,7 +1742,7 @@ version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecf3f420a81c1ee22868fba85872fb7146bd4f4bc1185de579655a4c71849e8a"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "brotli",
  "cc",
  "chrono",
@@ -1841,7 +1824,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1879,7 +1861,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2268,7 +2250,7 @@ version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "getrandom 0.2.17",
  "js-sys",
  "pem",
@@ -2394,7 +2376,6 @@ dependencies = [
  "celes",
  "compact_str",
  "criterion",
- "elasticsearch",
  "float-cmp",
  "itertools 0.15.0",
  "jiff",
@@ -2402,11 +2383,12 @@ dependencies = [
  "libmotiva-macros",
  "luhn",
  "metrics",
+ "opensearch",
  "opentelemetry",
  "pyo3",
  "rand 0.10.2",
  "regex",
- "reqwest 0.13.4",
+ "reqwest",
  "rphonetic",
  "rust-embed",
  "serde",
@@ -2578,7 +2560,7 @@ version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1db0d8f1fc9e62caebd0319e11eaec5822b0186c171568f0480b46a0137f9108"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "evmap",
  "http-body-util",
  "hyper",
@@ -2672,6 +2654,7 @@ dependencies = [
  "axum-extra",
  "axum-macros",
  "axum-test",
+ "base64 0.23.1",
  "gcp_auth",
  "glob",
  "hurl",
@@ -2689,7 +2672,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "reqwest 0.13.4",
+ "reqwest",
  "rustls",
  "rusty-fork",
  "serde",
@@ -2882,6 +2865,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "opensearch"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af6815a23449a0860c8fe049a828c3589d3ad56d3b5875d0d1f340d1291871e"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "dyn-clone",
+ "lazy_static",
+ "percent-encoding",
+ "reqwest",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "url",
+ "void",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2972,7 +2975,7 @@ dependencies = [
  "bytes",
  "http",
  "opentelemetry",
- "reqwest 0.13.4",
+ "reqwest",
 ]
 
 [[package]]
@@ -2987,7 +2990,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.13.4",
+ "reqwest",
  "thiserror",
  "tokio",
  "tonic",
@@ -3076,7 +3079,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -3659,49 +3662,11 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http 0.6.11",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -4207,7 +4172,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bs58",
  "chrono",
  "hex",
@@ -4766,7 +4731,7 @@ checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http",
@@ -5328,15 +5293,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "whatlang"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5542,7 +5498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "base64",
+ "base64 0.22.1",
  "deadpool",
  "futures",
  "http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,6 +205,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-config"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a767267da9e2c2e189b2f9df8b5657e850ecf5352644734ba130d4a57095cf1b"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.2",
+ "sha1",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e93964ffdaf57857f544be3666a5f57570bb699e934700f11b49708f61bb556e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +272,337 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-runtime"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9007227e10b5fed2f3e0a2beff489211e2b5604c400b7a9d5d81ca9d64c24bb"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 1.4.2",
+ "http-body 1.1.0",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.107.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "769b0abd0f89cfe11da5099986dd493e4f94347ce9a4562cb86ddecfe926b6c0"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.109.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4075b8a2c8cda4076a3dcc43b9d6dabd93e0c2502abeaaf7e14aaead9bb312b"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.112.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f582002918346a3e685be1b391c7bea155073088cea6bd4e4b7663df9e43b6c"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723c2234ad7511ceef63eab016b7ba6ff7c55590fefb96fa8467af014a07309f"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.2",
+ "percent-encoding",
+ "sha2",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.2",
+ "http-body 1.1.0",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebfd138fac0337cee7516c352757ea73b9f2266e57d0bcb5bc70e9547e45aef1"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2",
+ "http 1.4.2",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc65a121adb4b33729919fcfa14fa36fb33c1555a8f06bb0e2188dbfdc1d9ef"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512346c7212ab7436df2d77a16d976a468ae44a418835511d2a69269810aaf62"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b82e438d30e02a825d363bd639a9efaed68a8089d86101054b0081e7e0d3e606"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "http-body 0.4.6",
+ "http-body 1.1.0",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "954c563ce84507722d2679f07a35d21b9c6466b3872d513020d0281fc8112ac9"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.2",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "aws-smithy-schema"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.2",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fce83ce9abbb198d25bc7131e468d0f9fe1257125e58c39f3f9fc9f5098c9647"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "http 0.2.12",
+ "http 1.4.2",
+ "http-body 0.4.6",
+ "http-body 1.1.0",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce84f71c72fee2cbbadde6e7d082f5fb466e3a84733855295fa7aafd1b31b7d8"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eec1cd5469f328c782dc3e33d4153cf118a54e33cbb3356d60d16f89883e1f94"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,8 +613,8 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -261,8 +644,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -285,8 +668,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "headers",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -322,7 +705,7 @@ dependencies = [
  "cookie",
  "educe",
  "expect-json",
- "http",
+ "http 1.4.2",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -349,6 +732,16 @@ name = "base64"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "bindgen"
@@ -474,6 +867,16 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "bytesize"
@@ -638,6 +1041,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
@@ -870,6 +1279,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curl"
 version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,6 +1481,7 @@ dependencies = [
  "block-buffer 0.12.1",
  "const-oid",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1473,7 +1892,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "chrono",
- "http",
+ "http 1.4.2",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -1584,7 +2003,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.2",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -1652,7 +2071,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "headers-core",
- "http",
+ "http 1.4.2",
  "httpdate",
  "mime",
  "sha1",
@@ -1664,7 +2083,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -1692,6 +2111,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,12 +2142,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -1719,8 +2169,8 @@ checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "pin-project-lite",
 ]
 
@@ -1799,8 +2249,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "httparse",
  "httpdate",
  "itoa",
@@ -1816,7 +2266,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
+ "http 1.4.2",
  "hyper",
  "hyper-util",
  "rustls",
@@ -1865,8 +2315,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "hyper",
  "ipnet",
  "libc",
@@ -2371,6 +2821,7 @@ dependencies = [
  "aho-corasick",
  "any_ascii",
  "anyhow",
+ "aws-config",
  "bon",
  "bumpalo",
  "celes",
@@ -2870,6 +3321,10 @@ version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af6815a23449a0860c8fe049a828c3589d3ad56d3b5875d0d1f340d1291871e"
 dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-runtime-api",
+ "aws-types",
  "base64 0.22.1",
  "bytes",
  "dyn-clone",
@@ -2973,7 +3428,7 @@ checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
- "http",
+ "http 1.4.2",
  "opentelemetry",
  "reqwest",
 ]
@@ -2984,7 +3439,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
- "http",
+ "http 1.4.2",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
@@ -3039,6 +3494,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "page_size"
@@ -3157,6 +3618,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -3655,6 +4122,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3672,8 +4145,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -3806,7 +4279,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
+ "http 1.4.2",
  "mime",
  "rand 0.10.2",
  "thiserror",
@@ -4734,8 +5207,8 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "http-body-util",
  "hyper",
  "hyper-timeout",
@@ -4806,8 +5279,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "http-body-util",
  "pin-project-lite",
  "tokio",
@@ -4826,8 +5299,8 @@ checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
  "bitflags 2.13.1",
  "bytes",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "percent-encoding",
  "pin-project-lite",
  "tokio",
@@ -5077,6 +5550,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5151,6 +5630,12 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wait-timeout"
@@ -5501,7 +5986,7 @@ dependencies = [
  "base64 0.22.1",
  "deadpool",
  "futures",
- "http",
+ "http 1.4.2",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -5531,6 +6016,12 @@ name = "xml"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "636f85e5ca6488e96401b61eb7de54f4e44755c988af0f52cf90230c312a1a89"
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yansi"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,14 @@
-ARG BASE=native
-
-# Distroless image if not building native dependencies
-FROM lukemathwalker/cargo-chef:latest-rust-1.93.0-slim-bookworm AS base-native
+FROM lukemathwalker/cargo-chef:latest-rust-1.98.0-slim-bookworm AS base
 RUN apt update && apt install -y pkg-config libssl-dev
 
-FROM base-${BASE} AS planner
+FROM base AS planner
 
 WORKDIR /app
 
 COPY . .
 RUN cargo chef prepare --bin motiva --recipe-path recipe.json
 
-# Fork base layer depending on whether we build native dependencies
-FROM base-${BASE} AS builder
+FROM base AS builder
 ARG CARGO_ARGS=""
 
 WORKDIR /app

--- a/crates/libmotiva/Cargo.toml
+++ b/crates/libmotiva/Cargo.toml
@@ -23,15 +23,13 @@ bon = { version = "3.6.5" }
 bumpalo = { version = "3.19.0", features = ["collections"] }
 celes = "2.8.2"
 compact_str = "0.10.0"
-elasticsearch = { version = "9.1.0-alpha.1", default-features = false, features = [
-    "rustls-tls",
-] }
 itertools = "0.15.0"
 jiff = { version = "0.2.15", features = ["serde"] }
 lei = "0.2.5"
 libmotiva-macros = { version = "0.2.0", path = "../macros" }
 luhn = "1.0.1"
 metrics = "0.24.2"
+opensearch = { version = "2.4.0", default-features = false, features = ["rustls-tls"] }
 opentelemetry = { version = "0.32.0", features = ["trace"] }
 rand = "0.10.1"
 regex = "1.11.1"

--- a/crates/libmotiva/Cargo.toml
+++ b/crates/libmotiva/Cargo.toml
@@ -55,12 +55,16 @@ validator = { version = "0.21.0", features = ["derive"] }
 whatlang = "0.18.0"
 
 [dev-dependencies]
+aws-credential-types = "1.3.0"
+aws-sigv4 = "1.5.1"
+aws-smithy-runtime-api = { version = "1.15.0", features = ["client"] }
 criterion = { version = "0.8.1", features = ["async_tokio"] }
 float-cmp = "0.10.0"
 pyo3 = { version = "0.29.0" }
 serde-json-assert = "0.4.0"
 serial_test = "4.0"
 std-macro-extensions = "^1"
+temp-env = { version = "0.3.6", features = ["async_closure"] }
 tokio-test = "0.4.4"
 wiremock = "0.6.5"
 

--- a/crates/libmotiva/Cargo.toml
+++ b/crates/libmotiva/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/apognu/motiva"
 documentation = "https://docs.rs/libmotiva"
 
 [features]
+aws = ["opensearch/aws-auth", "aws-config"]
 benchmarks = []
 
 [dependencies]
@@ -19,6 +20,7 @@ ahash = { version = "0.8.12", features = ["serde"] }
 aho-corasick = "1.1.3"
 any_ascii = "0.3.3"
 anyhow = "1.0.98"
+aws-config = { version = "1.11.0", optional = true }
 bon = { version = "3.6.5" }
 bumpalo = { version = "3.19.0", features = ["collections"] }
 celes = "2.8.2"

--- a/crates/libmotiva/README.md
+++ b/crates/libmotiva/README.md
@@ -49,29 +49,31 @@ Before v0.5.0, motiva is only compatible with data indexer with Yente v4.x. Star
 
 Motiva is configured via environment variables. The following variables are supported:
 
-| Variable                   | Description                                                                            | Default / Example         |
-| -------------------------- | -------------------------------------------------------------------------------------- | ------------------------- |
-| `ENV`                      | Environment (`dev` or `production`)                                                    | `dev`                     |
-| `LISTEN_ADDR`              | Address to bind the API server                                                         | `0.0.0.0:8000`            |
-| `API_KEY`                  | Bearer token used to authenticate requests                                             | _(none)_                  |
-| `INDEX_URL`                | Elasticsearch URL                                                                      | `http://localhost:9200`   |
-| `INDEX_AUTH_METHOD`        | Elasticsearch authentication (`none`, `basic`, `bearer`, `api_key`, `encoded_api_key`) | `none`                    |
-| `INDEX_CLIENT_ID`          | Elasticsearch client ID (required for `basic` or `api_key`)                            | _(none)_                  |
-| `INDEX_CLIENT_SECRET`      | Elasticsearch client secret (required for `basic`, `api_key` or `encoded_api_key`)     | _(none)_                  |
-| `INDEX_TLS_CA_CERT`        | Path to a PEM-encoded certificate chain to use for TLS validation                      | _(none)_                  |
-| `INDEX_TLS_SKIP_VERIFY`    | If `1`, do not validate the TLS certificate served by the Elasticsearch cluster        | `0`                       |
-| `INDEX_NAME`               | Index prefix under which data was indexed (suffixed by `-entities`)                    | `yente`                   |
-| `MANIFEST_URL`             | Optional URL to a custom manifest JSON file                                            | _(none)_                  |
-| `CATALOG_REFRESH_INTERVAL` | Interval at which to pull the manifest and catalogs                                    | _1h_                      |
-| `MATCH_CANDIDATES`         | Number of candidates to consider for matching                                          | `10`                      |
-| `WEIGHT_<FEATURE_NAME>`    | Custom weight for a given feature (e.g. `WEIGHT_PERSON_NAME_JARO_WINKLER`)             | _(none)_                  |
-| `ENRICHMENT_MAX_RECURSION` | Maximum recursion levels when enriching entities with relations                        | `2`                       |
-| `ENRICHMENT_QUERY_LIMIT`   | Maximum relation documents to fetch from Elasticsearch when building relation graphs   | `200`                     |
-| `ENABLE_PROMETHEUS`        | Enable Prometheus metrics collection and /metrics endpoint                             | `0`                       |
-| `ENABLE_TRACING`           | Set to `1` to enable tracing                                                           | _(none)_                  |
-| `TRACING_EXPORTER`         | Tracing exporter kind (`otlp`, or `gcp` if compiled with the `gcp` feature)            | `otlp`                    |
-| `REQUEST_TIMEOUT`          | Maximum duration for a match request                                                   | _10s_                     |
-| `SCOPED_INDEX_QUERY`       | Query used to scope down the index used for match queries                              | [see here](#scoped-index) |
+| Variable                   | Description                                                                                                        | Default / Example         |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------- |
+| `ENV`                      | Environment (`dev` or `production`)                                                                                | `dev`                     |
+| `LISTEN_ADDR`              | Address to bind the API server                                                                                     | `0.0.0.0:8000`            |
+| `API_KEY`                  | Bearer token used to authenticate requests                                                                         | _(none)_                  |
+| `INDEX_URL`                | Elasticsearch URL                                                                                                  | `http://localhost:9200`   |
+| `INDEX_AUTH_METHOD`        | Elasticsearch authentication (`none`, `basic`, `bearer`, `api_key`, `encoded_api_key`, `aws-iam-*` <sup>[1]</sup>) | `none`                    |
+| `INDEX_CLIENT_ID`          | Elasticsearch client ID (required for `basic` or `api_key`)                                                        | _(none)_                  |
+| `INDEX_CLIENT_SECRET`      | Elasticsearch client secret (required for `basic`, `api_key` or `encoded_api_key`)                                 | _(none)_                  |
+| `INDEX_TLS_CA_CERT`        | Path to a PEM-encoded certificate chain to use for TLS validation                                                  | _(none)_                  |
+| `INDEX_TLS_SKIP_VERIFY`    | If `1`, do not validate the TLS certificate served by the Elasticsearch cluster                                    | `0`                       |
+| `INDEX_NAME`               | Index prefix under which data was indexed (suffixed by `-entities`)                                                | `yente`                   |
+| `MANIFEST_URL`             | Optional URL to a custom manifest JSON file                                                                        | _(none)_                  |
+| `CATALOG_REFRESH_INTERVAL` | Interval at which to pull the manifest and catalogs                                                                | _1h_                      |
+| `MATCH_CANDIDATES`         | Number of candidates to consider for matching                                                                      | `10`                      |
+| `WEIGHT_<FEATURE_NAME>`    | Custom weight for a given feature (e.g. `WEIGHT_PERSON_NAME_JARO_WINKLER`)                                         | _(none)_                  |
+| `ENRICHMENT_MAX_RECURSION` | Maximum recursion levels when enriching entities with relations                                                    | `2`                       |
+| `ENRICHMENT_QUERY_LIMIT`   | Maximum relation documents to fetch from Elasticsearch when building relation graphs                               | `200`                     |
+| `ENABLE_PROMETHEUS`        | Enable Prometheus metrics collection and /metrics endpoint                                                         | `0`                       |
+| `ENABLE_TRACING`           | Set to `1` to enable tracing                                                                                       | _(none)_                  |
+| `TRACING_EXPORTER`         | Tracing exporter kind (`otlp`, or `gcp` if compiled with the `gcp` feature)                                        | `otlp`                    |
+| `REQUEST_TIMEOUT`          | Maximum duration for a match request                                                                               | _10s_                     |
+| `SCOPED_INDEX_QUERY`       | Query used to scope down the index used for match queries                                                          | [see here](#scoped-index) |
+
+<sup>[1]</sup>: See section [**OpenSearch AWS IAM authentication**](#opensearch-aws-iam-authentication).
 
 Setting `MANIFEST_FILE` is required if you use a customized dataset list and would like your own manifest to be used for catalog generation. If omitted, the default manifest provided by Yente will be used. It requires either an HTTP URL or a local file path ending in `.json`, `.yml` or `.yaml`.
 
@@ -193,6 +195,14 @@ The default scoped query is listed below, but can be customized through `SCOPED_
 The scoped index is not kept automatically in sync with the full index, you would need to run `motiva create-scoped-index` again when you need to update it. We suggest running it after your regular indexing operations.
 
 Once your scoped index is created, you can perform a `/match` request with the Motiva-specific `?index_type=scoped` parameters for the new index to be used.
+
+## OpenSearch AWS IAM authentication
+
+If running with the `aws` feature, authenticating to both versions of AWS's managed OpenSearch is possible by using `INDEX_AUTH_METHOD=aws-iam-service` for OpenSearch Service and `INDEX_AUTH_METHOD=aws-iam-serverless` for OpenSearch Serverless.
+
+When used, the usual credential providers will be used (environment variables, profile, web identity, ECS container, IMDSv2), in order, to load credentials used to sign requests to the OpenSearch cluster.
+
+The region used will be determined on a best-effort basis (through environment variables, profile, then IMDSv2) depending on where motiva runs. If running outside AWS or if your OpenSearch instance lives in another region, you may specify it through the usual `AWS_REGION`.
 
 ## Run
 

--- a/crates/libmotiva/README.md
+++ b/crates/libmotiva/README.md
@@ -54,7 +54,7 @@ Motiva is configured via environment variables. The following variables are supp
 | `LISTEN_ADDR`              | Address to bind the API server                                                                       | `0.0.0.0:8000`            |
 | `API_KEY`                  | Bearer token used to authenticate requests                                                           | _(none)_                  |
 | `INDEX_URL`                | Elasticsearch URL                                                                                    | `http://localhost:9200`   |
-| `INDEX_AUTH_METHOD`        | Index authentication (`none`, `basic`, `bearer`, `api_key`, `api_token`, `aws-iam-*` <sup>[1]</sup>) | `none`                    |
+| `INDEX_AUTH_METHOD`        | Index authentication (`none`, `basic`, `bearer`, `api_key`, `api_token`, `aws_iam_*` <sup>[1]</sup>) | `none`                    |
 | `INDEX_CLIENT_ID`          | Elasticsearch client ID (required for `basic` or `api_key`)                                          | _(none)_                  |
 | `INDEX_CLIENT_SECRET`      | Client secret (required for `basic`, `api_key`, `encoded_api_key` or `api_token`)                    | _(none)_                  |
 | `INDEX_TLS_CA_CERT`        | Path to a PEM-encoded certificate chain to use for TLS validation                                    | _(none)_                  |
@@ -72,7 +72,7 @@ Motiva is configured via environment variables. The following variables are supp
 | `REQUEST_TIMEOUT`          | Maximum duration for a match request                                                                 | _10s_                     |
 | `SCOPED_INDEX_QUERY`       | Query used to scope down the index used for match queries                                            | [see here](#scoped-index) |
 
-<sup>[1]</sup>: See section [**OpenSearch AWS IAM authentication**](#opensearch-aws-iam-authentication).
+<sup>[1]</sup>: Only available with the `aws` feature. See section [**OpenSearch AWS IAM authentication**](#opensearch-aws-iam-authentication).
 
 Note that `api_key` and `api_token` are two different schemes, despite both being sent under the `ApiKey` HTTP authorization scheme:
 
@@ -202,7 +202,7 @@ Once your scoped index is created, you can perform a `/match` request with the M
 
 ## OpenSearch AWS IAM authentication
 
-If running with the `aws` feature, authenticating to both versions of AWS's managed OpenSearch is possible by using `INDEX_AUTH_METHOD=aws-iam-service` for OpenSearch Service and `INDEX_AUTH_METHOD=aws-iam-serverless` for OpenSearch Serverless.
+If running with the `aws` feature, authenticating to both versions of AWS's managed OpenSearch is possible by using `INDEX_AUTH_METHOD=aws_iam_service` for OpenSearch Service and `INDEX_AUTH_METHOD=aws_iam_serverless` for OpenSearch Serverless.
 
 When used, the usual credential providers will be used (environment variables, profile, web identity, ECS container, IMDSv2), in order, to load credentials used to sign requests to the OpenSearch cluster.
 

--- a/crates/libmotiva/README.md
+++ b/crates/libmotiva/README.md
@@ -37,7 +37,6 @@ Some liberty was taken to adapt some logic and algorithms from Yente, so do not 
 - [x] name-based
 - [x] name-qualified
 - [x] logic-v1 <sup>[1]</sup>
-- [ ] logic-v2
 
 <sup>[1]</sup>: Features that are disabled by default were omited for now.
 
@@ -49,31 +48,36 @@ Before v0.5.0, motiva is only compatible with data indexer with Yente v4.x. Star
 
 Motiva is configured via environment variables. The following variables are supported:
 
-| Variable                   | Description                                                                                                        | Default / Example         |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------- |
-| `ENV`                      | Environment (`dev` or `production`)                                                                                | `dev`                     |
-| `LISTEN_ADDR`              | Address to bind the API server                                                                                     | `0.0.0.0:8000`            |
-| `API_KEY`                  | Bearer token used to authenticate requests                                                                         | _(none)_                  |
-| `INDEX_URL`                | Elasticsearch URL                                                                                                  | `http://localhost:9200`   |
-| `INDEX_AUTH_METHOD`        | Elasticsearch authentication (`none`, `basic`, `bearer`, `api_key`, `encoded_api_key`, `aws-iam-*` <sup>[1]</sup>) | `none`                    |
-| `INDEX_CLIENT_ID`          | Elasticsearch client ID (required for `basic` or `api_key`)                                                        | _(none)_                  |
-| `INDEX_CLIENT_SECRET`      | Elasticsearch client secret (required for `basic`, `api_key` or `encoded_api_key`)                                 | _(none)_                  |
-| `INDEX_TLS_CA_CERT`        | Path to a PEM-encoded certificate chain to use for TLS validation                                                  | _(none)_                  |
-| `INDEX_TLS_SKIP_VERIFY`    | If `1`, do not validate the TLS certificate served by the Elasticsearch cluster                                    | `0`                       |
-| `INDEX_NAME`               | Index prefix under which data was indexed (suffixed by `-entities`)                                                | `yente`                   |
-| `MANIFEST_URL`             | Optional URL to a custom manifest JSON file                                                                        | _(none)_                  |
-| `CATALOG_REFRESH_INTERVAL` | Interval at which to pull the manifest and catalogs                                                                | _1h_                      |
-| `MATCH_CANDIDATES`         | Number of candidates to consider for matching                                                                      | `10`                      |
-| `WEIGHT_<FEATURE_NAME>`    | Custom weight for a given feature (e.g. `WEIGHT_PERSON_NAME_JARO_WINKLER`)                                         | _(none)_                  |
-| `ENRICHMENT_MAX_RECURSION` | Maximum recursion levels when enriching entities with relations                                                    | `2`                       |
-| `ENRICHMENT_QUERY_LIMIT`   | Maximum relation documents to fetch from Elasticsearch when building relation graphs                               | `200`                     |
-| `ENABLE_PROMETHEUS`        | Enable Prometheus metrics collection and /metrics endpoint                                                         | `0`                       |
-| `ENABLE_TRACING`           | Set to `1` to enable tracing                                                                                       | _(none)_                  |
-| `TRACING_EXPORTER`         | Tracing exporter kind (`otlp`, or `gcp` if compiled with the `gcp` feature)                                        | `otlp`                    |
-| `REQUEST_TIMEOUT`          | Maximum duration for a match request                                                                               | _10s_                     |
-| `SCOPED_INDEX_QUERY`       | Query used to scope down the index used for match queries                                                          | [see here](#scoped-index) |
+| Variable                   | Description                                                                                          | Default / Example         |
+| -------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------- |
+| `ENV`                      | Environment (`dev` or `production`)                                                                  | `dev`                     |
+| `LISTEN_ADDR`              | Address to bind the API server                                                                       | `0.0.0.0:8000`            |
+| `API_KEY`                  | Bearer token used to authenticate requests                                                           | _(none)_                  |
+| `INDEX_URL`                | Elasticsearch URL                                                                                    | `http://localhost:9200`   |
+| `INDEX_AUTH_METHOD`        | Index authentication (`none`, `basic`, `bearer`, `api_key`, `api_token`, `aws-iam-*` <sup>[1]</sup>) | `none`                    |
+| `INDEX_CLIENT_ID`          | Elasticsearch client ID (required for `basic` or `api_key`)                                          | _(none)_                  |
+| `INDEX_CLIENT_SECRET`      | Client secret (required for `basic`, `api_key`, `encoded_api_key` or `api_token`)                    | _(none)_                  |
+| `INDEX_TLS_CA_CERT`        | Path to a PEM-encoded certificate chain to use for TLS validation                                    | _(none)_                  |
+| `INDEX_TLS_SKIP_VERIFY`    | If `1`, do not validate the TLS certificate served by the Elasticsearch cluster                      | `0`                       |
+| `INDEX_NAME`               | Index prefix under which data was indexed (suffixed by `-entities`)                                  | `yente`                   |
+| `MANIFEST_URL`             | Optional URL to a custom manifest JSON file                                                          | _(none)_                  |
+| `CATALOG_REFRESH_INTERVAL` | Interval at which to pull the manifest and catalogs                                                  | _1h_                      |
+| `MATCH_CANDIDATES`         | Number of candidates to consider for matching                                                        | `10`                      |
+| `WEIGHT_<FEATURE_NAME>`    | Custom weight for a given feature (e.g. `WEIGHT_PERSON_NAME_JARO_WINKLER`)                           | _(none)_                  |
+| `ENRICHMENT_MAX_RECURSION` | Maximum recursion levels when enriching entities with relations                                      | `2`                       |
+| `ENRICHMENT_QUERY_LIMIT`   | Maximum relation documents to fetch from Elasticsearch when building relation graphs                 | `200`                     |
+| `ENABLE_PROMETHEUS`        | Enable Prometheus metrics collection and /metrics endpoint                                           | `0`                       |
+| `ENABLE_TRACING`           | Set to `1` to enable tracing                                                                         | _(none)_                  |
+| `TRACING_EXPORTER`         | Tracing exporter kind (`otlp`, or `gcp` if compiled with the `gcp` feature)                          | `otlp`                    |
+| `REQUEST_TIMEOUT`          | Maximum duration for a match request                                                                 | _10s_                     |
+| `SCOPED_INDEX_QUERY`       | Query used to scope down the index used for match queries                                            | [see here](#scoped-index) |
 
 <sup>[1]</sup>: See section [**OpenSearch AWS IAM authentication**](#opensearch-aws-iam-authentication).
+
+Note that `api_key` and `api_token` are two different schemes, despite both being sent under the `ApiKey` HTTP authorization scheme:
+
+- `api_key` (and `encoded_api_key`) is Elasticsearch's two-part credential, a client ID and a secret, transmitted as `ApiKey base64(id:secret)`. Set both `INDEX_CLIENT_ID` and `INDEX_CLIENT_SECRET` (or, for `encoded_api_key`, put the already-base64-encoded `id:secret` in `INDEX_CLIENT_SECRET` alone).
+- `api_token` is OpenSearch's own single opaque token, transmitted verbatim as `ApiKey <token>`. Put the whole token in `INDEX_CLIENT_SECRET` and leave `INDEX_CLIENT_ID` unset.
 
 Setting `MANIFEST_FILE` is required if you use a customized dataset list and would like your own manifest to be used for catalog generation. If omitted, the default manifest provided by Yente will be used. It requires either an HTTP URL or a local file path ending in `.json`, `.yml` or `.yaml`.
 

--- a/crates/libmotiva/src/error.rs
+++ b/crates/libmotiva/src/error.rs
@@ -11,7 +11,7 @@ pub enum MotivaError {
   #[error("invalid schema: {0}")]
   InvalidSchema(String),
   #[error(transparent)]
-  IndexError(#[from] elasticsearch::Error),
+  IndexError(#[from] opensearch::Error),
   #[error(transparent)]
   OtherError(#[from] anyhow::Error),
 }

--- a/crates/libmotiva/src/index/elastic/builder.rs
+++ b/crates/libmotiva/src/index/elastic/builder.rs
@@ -28,6 +28,21 @@ impl ElasticsearchProvider {
         EsAuthMethod::Basic(username, password) => transport.auth(Credentials::Basic(username, password)),
         EsAuthMethod::Bearer(token) => transport.auth(Credentials::Bearer(token)),
         EsAuthMethod::ApiKey(client_id, client_secret) => transport.auth(Credentials::ApiKey(client_id, client_secret)),
+
+        #[cfg(feature = "aws")]
+        EsAuthMethod::AwsIam(service) => {
+          use aws_config::{BehaviorVersion, meta::region::RegionProviderChain};
+
+          let region = RegionProviderChain::default_provider().or_else("us-east-1");
+          let iam = aws_config::defaults(BehaviorVersion::latest()).region(region).load().await.clone();
+          let transport = transport.auth(iam.try_into()?);
+
+          match service {
+            AwsService::Service => transport.service_name("es"),
+            AwsService::Serverless => transport.service_name("aoss"),
+          }
+        }
+
         _ => transport,
       };
 
@@ -85,6 +100,20 @@ pub enum EsAuthMethod {
   Bearer(String),
   /// API key (client ID and API key)
   ApiKey(String, String),
+
+  #[cfg(feature = "aws")]
+  /// AWS IAM
+  AwsIam(AwsService),
+}
+
+#[cfg(feature = "aws")]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub enum AwsService {
+  /// Amazon OpenSearch
+  #[default]
+  Service,
+  /// Amazon OpenSearch Serverless
+  Serverless,
 }
 
 /// TLS certificate method to use when using an HTTPS URL
@@ -170,6 +199,17 @@ mod tests {
       EsOptions {
         auth: EsAuthMethod::Basic(u.clone(), p.clone()),
         tls: &EsTlsVerification::CaCertChain(cert.as_bytes().to_vec()),
+        ..Default::default()
+      },
+    )
+    .await
+    .unwrap();
+
+    #[cfg(feature = "aws")]
+    ElasticsearchProvider::new(
+      "http://url:9200",
+      EsOptions {
+        auth: EsAuthMethod::AwsIam(super::AwsService::Serverless),
         ..Default::default()
       },
     )

--- a/crates/libmotiva/src/index/elastic/builder.rs
+++ b/crates/libmotiva/src/index/elastic/builder.rs
@@ -5,11 +5,11 @@ use crate::index::elastic::config::EsOptions;
 use crate::index::elastic::{DEFAULT_INDEX_PREFIX, IndexState, SCOPED_INDEX_SUFFIX};
 use crate::{error::MotivaError, index::elastic::config::IndexVersion, prelude::ElasticsearchProvider};
 use anyhow::Context;
-use elasticsearch::cert::{Certificate, CertificateValidation};
-use elasticsearch::http::Url;
-use elasticsearch::http::transport::{SingleNodeConnectionPool, TransportBuilder};
-use elasticsearch::indices::IndicesGetAliasParts;
-use elasticsearch::{Elasticsearch, auth::Credentials};
+use opensearch::cert::{Certificate, CertificateValidation};
+use opensearch::http::Url;
+use opensearch::http::transport::{SingleNodeConnectionPool, TransportBuilder};
+use opensearch::indices::IndicesGetAliasParts;
+use opensearch::{OpenSearch, auth::Credentials};
 use reqwest::StatusCode;
 
 impl ElasticsearchProvider {
@@ -24,17 +24,16 @@ impl ElasticsearchProvider {
         EsTlsVerification::CaCertChain(pem) => transport_builder.cert_validation(CertificateValidation::Full(Certificate::from_pem(pem)?)),
       };
 
+      let transport = match options.auth {
+        EsAuthMethod::Basic(username, password) => transport.auth(Credentials::Basic(username, password)),
+        EsAuthMethod::Bearer(token) => transport.auth(Credentials::Bearer(token)),
+        EsAuthMethod::ApiKey(client_id, client_secret) => transport.auth(Credentials::ApiKey(client_id, client_secret)),
+        _ => transport,
+      };
+
       let transport = transport.build().context("could not build index client")?;
 
-      match options.auth {
-        EsAuthMethod::Basic(username, password) => transport.set_auth(Credentials::Basic(username, password)),
-        EsAuthMethod::Bearer(token) => transport.set_auth(Credentials::Bearer(token)),
-        EsAuthMethod::ApiKey(client_id, client_secret) => transport.set_auth(Credentials::ApiKey(client_id, client_secret)),
-        EsAuthMethod::EncodedApiKey(api_key) => transport.set_auth(Credentials::EncodedApiKey(api_key)),
-        _ => {}
-      }
-
-      Elasticsearch::new(transport)
+      OpenSearch::new(transport)
     };
 
     let index_prefix = options.index_name.unwrap_or_else(|| DEFAULT_INDEX_PREFIX.to_string());
@@ -86,8 +85,6 @@ pub enum EsAuthMethod {
   Bearer(String),
   /// API key (client ID and API key)
   ApiKey(String, String),
-  /// API key
-  EncodedApiKey(String),
 }
 
 /// TLS certificate method to use when using an HTTPS URL
@@ -118,7 +115,7 @@ mod tests {
     index::elastic::{IndexState, config::IndexVersion},
     prelude::{ElasticsearchProvider, EsAuthMethod},
   };
-  use elasticsearch::Elasticsearch;
+  use opensearch::OpenSearch;
 
   #[tokio::test]
   async fn es_builder() {
@@ -151,16 +148,6 @@ mod tests {
       "http://url:9200",
       EsOptions {
         auth: EsAuthMethod::ApiKey(u.clone(), p.clone()),
-        ..Default::default()
-      },
-    )
-    .await
-    .unwrap();
-
-    ElasticsearchProvider::new(
-      "http://url:9200",
-      EsOptions {
-        auth: EsAuthMethod::EncodedApiKey(p.clone()),
         ..Default::default()
       },
     )
@@ -218,7 +205,7 @@ mod tests {
 
   fn provider_with_prefix(prefix: &str) -> ElasticsearchProvider {
     ElasticsearchProvider {
-      es: Elasticsearch::default(),
+      es: OpenSearch::default(),
       index_prefix: prefix.to_string(),
       main_index: format!("{prefix}-entities"),
       state: Arc::new(RwLock::new(IndexState {

--- a/crates/libmotiva/src/index/elastic/builder.rs
+++ b/crates/libmotiva/src/index/elastic/builder.rs
@@ -34,7 +34,7 @@ impl ElasticsearchProvider {
           use aws_config::{BehaviorVersion, meta::region::RegionProviderChain};
 
           let region = RegionProviderChain::default_provider().or_else("us-east-1");
-          let iam = aws_config::defaults(BehaviorVersion::latest()).region(region).load().await.clone();
+          let iam = aws_config::defaults(BehaviorVersion::latest()).region(region).load().await;
           let transport = transport.auth(iam.try_into()?);
 
           match service {
@@ -204,17 +204,6 @@ mod tests {
     )
     .await
     .unwrap();
-
-    #[cfg(feature = "aws")]
-    ElasticsearchProvider::new(
-      "http://url:9200",
-      EsOptions {
-        auth: EsAuthMethod::AwsIam(super::AwsService::Serverless),
-        ..Default::default()
-      },
-    )
-    .await
-    .unwrap();
   }
 
   #[tokio::test]
@@ -270,5 +259,156 @@ mod tests {
 
     assert_eq!(provider.main_index, "yente-entities");
     assert_eq!(provider.scoped_alias_name(), "yente-motiva-scoped-entities");
+  }
+
+  #[cfg(feature = "aws")]
+  mod aws_sigv4 {
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    use aws_credential_types::Credentials;
+    use aws_sigv4::http_request::{PayloadChecksumKind, SignableBody, SignableRequest, SigningParams, SigningSettings, sign};
+    use aws_sigv4::sign::v4;
+    use aws_smithy_runtime_api::client::identity::Identity;
+    use jiff::civil::DateTime;
+    use jiff::tz::TimeZone;
+    use serde_json::json;
+    use wiremock::{
+      Mock, MockServer, Request, ResponseTemplate,
+      matchers::{method, path},
+    };
+
+    use crate::index::elastic::builder::AwsService;
+    use crate::index::elastic::config::EsOptions;
+    use crate::prelude::{ElasticsearchProvider, EsAuthMethod};
+
+    const ACCESS_KEY: &str = "AKIDEXAMPLE";
+    const SECRET_KEY: &str = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+    const REGION: &str = "us-east-1";
+    const EMPTY_PAYLOAD_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+    const SIGNED_HEADERS: &str = "accept;content-type;host;x-amz-content-sha256;x-amz-date";
+
+    const AWS_ENV: [(&str, Option<&str>); 9] = [
+      ("AWS_REGION", Some(REGION)),
+      ("AWS_DEFAULT_REGION", Some(REGION)),
+      ("AWS_ACCESS_KEY_ID", Some(ACCESS_KEY)),
+      ("AWS_SECRET_ACCESS_KEY", Some(SECRET_KEY)),
+      ("AWS_SESSION_TOKEN", None),
+      ("AWS_PROFILE", None),
+      ("AWS_EC2_METADATA_DISABLED", Some("true")),
+      ("AWS_CONFIG_FILE", Some("/nonexistent/motiva/config")),
+      ("AWS_SHARED_CREDENTIALS_FILE", Some("/nonexistent/motiva/credentials")),
+    ];
+
+    async fn request(service: AwsService) -> (String, Request) {
+      let server = MockServer::start().await;
+
+      Mock::given(method("GET"))
+        .and(path("/yente-entities/_mapping"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "yente-entities": { "mappings": { "_source": { "excludes": ["name_keys"] } } }
+        })))
+        .mount(&server)
+        .await;
+
+      ElasticsearchProvider::new(
+        &server.uri(),
+        EsOptions {
+          auth: EsAuthMethod::AwsIam(service),
+          ..Default::default()
+        },
+      )
+      .await
+      .unwrap();
+
+      let request = server
+        .received_requests()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|request| request.url.path() == "/yente-entities/_mapping")
+        .expect("no request reached the mock server, signing failed");
+
+      (server.uri(), request)
+    }
+
+    fn header<'r>(request: &'r Request, name: &str) -> &'r str {
+      request.headers.get(name).expect("missing header").to_str().unwrap()
+    }
+
+    fn field<'a>(authorization: &'a str, name: &str) -> &'a str {
+      authorization
+        .split(", ")
+        .find_map(|part| part.trim_start_matches("AWS4-HMAC-SHA256 ").strip_prefix(&format!("{name}=")))
+        .expect("missing authorization header field")
+    }
+
+    fn parse_amz_date(date: &str) -> SystemTime {
+      let seconds = DateTime::strptime("%Y%m%dT%H%M%SZ", date)
+        .unwrap_or_else(|err| panic!("x-amz-date {date} is not a valid timestamp: {err}"))
+        .to_zoned(TimeZone::UTC)
+        .unwrap()
+        .timestamp()
+        .as_second();
+
+      UNIX_EPOCH + Duration::from_secs(seconds as u64)
+    }
+
+    fn expected_signature(base_url: &str, request: &Request, headers: &str, signed_at: SystemTime, service: &str) -> String {
+      let identity = Identity::new(Credentials::new(ACCESS_KEY, SECRET_KEY, None, None, "motiva-test"), None);
+
+      #[allow(clippy::field_reassign_with_default, reason = "SigningSettings is #[non_exhaustive]")]
+      let settings = {
+        let mut settings = SigningSettings::default();
+        settings.payload_checksum_kind = PayloadChecksumKind::XAmzSha256;
+        settings
+      };
+
+      let params = SigningParams::V4(
+        v4::SigningParams::builder()
+          .identity(&identity)
+          .name(service)
+          .region(REGION)
+          .time(signed_at)
+          .settings(settings)
+          .build()
+          .unwrap(),
+      );
+
+      let headers = headers.split(';').map(|name| (name, header(request, name))).collect::<Vec<_>>();
+      let uri = format!("{base_url}{}", request.url.path());
+      let signable = SignableRequest::new(request.method.as_str(), uri.as_str(), headers.into_iter(), SignableBody::Bytes(&[])).unwrap();
+
+      sign(signable, &params).unwrap().into_parts().1
+    }
+
+    async fn assert_request_is_signed(service: AwsService, expected_service: &str) {
+      let (base_url, request) = request(service).await;
+
+      let authorization = header(&request, "authorization");
+      let date = header(&request, "x-amz-date");
+      let signed_at = parse_amz_date(date);
+      let drift = SystemTime::now().duration_since(signed_at).unwrap_or_else(|err| err.duration());
+
+      assert!(drift < Duration::from_secs(300), "x-amz-date {date} is {drift:?} away from now");
+
+      assert!(authorization.starts_with("AWS4-HMAC-SHA256 "), "unexpected signature algorithm: {authorization}");
+      assert_eq!(header(&request, "x-amz-content-sha256"), EMPTY_PAYLOAD_SHA256);
+      assert_eq!(field(authorization, "Credential"), format!("{ACCESS_KEY}/{}/{REGION}/{expected_service}/aws4_request", &date[..8]));
+      assert_eq!(field(authorization, "SignedHeaders"), SIGNED_HEADERS);
+
+      assert_eq!(field(authorization, "Signature"), expected_signature(&base_url, &request, SIGNED_HEADERS, signed_at, expected_service));
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn signs_requests_for_managed_service() {
+      temp_env::async_with_vars(AWS_ENV, assert_request_is_signed(AwsService::Service, "es")).await;
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn signs_requests_for_serverless() {
+      temp_env::async_with_vars(AWS_ENV, assert_request_is_signed(AwsService::Serverless, "aoss")).await;
+    }
   }
 }

--- a/crates/libmotiva/src/index/elastic/builder.rs
+++ b/crates/libmotiva/src/index/elastic/builder.rs
@@ -13,8 +13,14 @@ use opensearch::{OpenSearch, auth::Credentials};
 use reqwest::StatusCode;
 use reqwest::header::{AUTHORIZATION, HeaderValue};
 
+#[cfg(feature = "aws")]
+const DEFAULT_AWS_REGION: &str = "us-east-1";
+
 impl ElasticsearchProvider {
   pub async fn new<'o>(url: &str, options: EsOptions<'o>) -> Result<ElasticsearchProvider, MotivaError> {
+    #[cfg(feature = "aws")]
+    let serverless = matches!(options.auth, EsAuthMethod::AwsIam(AwsService::Serverless));
+
     let es = {
       let parsed_url = Url::parse(url).context("invalid index URL")?;
       let transport_builder = TransportBuilder::new(SingleNodeConnectionPool::new(parsed_url));
@@ -33,9 +39,21 @@ impl ElasticsearchProvider {
 
         #[cfg(feature = "aws")]
         EsAuthMethod::AwsIam(service) => {
-          use aws_config::{BehaviorVersion, meta::region::RegionProviderChain};
+          use aws_config::{BehaviorVersion, Region, meta::region::RegionProviderChain};
 
-          let region = RegionProviderChain::default_provider().or_else("us-east-1");
+          let region = match RegionProviderChain::default_provider().region().await {
+            Some(region) => region,
+
+            None => {
+              tracing::warn!(
+                region = DEFAULT_AWS_REGION,
+                "could not detect an AWS region, falling back to a default, set AWS_REGION if your cluster lives elsewhere"
+              );
+
+              Region::new(DEFAULT_AWS_REGION)
+            }
+          };
+
           let iam = aws_config::defaults(BehaviorVersion::latest()).region(region).load().await;
           let transport = transport.auth(iam.try_into()?);
 
@@ -64,6 +82,8 @@ impl ElasticsearchProvider {
         index_version: IndexVersion::V4,
         scoped_index: None,
       })),
+      #[cfg(feature = "aws")]
+      serverless,
     };
 
     let _ = tokio::time::timeout(Duration::from_secs(5), provider.refresh_index_state()).await;
@@ -160,7 +180,11 @@ mod tests {
 
     let server = MockServer::start().await;
 
-    Mock::given(method("HEAD")).and(path("/yente-entities")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+    Mock::given(method("GET"))
+      .and(path("/_cluster/health/yente-entities"))
+      .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "status": "green" })))
+      .mount(&server)
+      .await;
 
     Mock::given(method("GET"))
       .and(path("/yente-entities/_mapping"))
@@ -296,6 +320,8 @@ mod tests {
         index_version: IndexVersion::V4,
         scoped_index: None,
       })),
+      #[cfg(feature = "aws")]
+      serverless: false,
     }
   }
 
@@ -357,6 +383,12 @@ mod tests {
       let server = MockServer::start().await;
 
       Mock::given(method("HEAD")).and(path("/yente-entities")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+
+      Mock::given(method("GET"))
+        .and(path("/_cluster/health/yente-entities"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "status": "green" })))
+        .mount(&server)
+        .await;
 
       Mock::given(method("GET"))
         .and(path("/yente-entities/_mapping"))

--- a/crates/libmotiva/src/index/elastic/builder.rs
+++ b/crates/libmotiva/src/index/elastic/builder.rs
@@ -11,6 +11,7 @@ use opensearch::http::transport::{SingleNodeConnectionPool, TransportBuilder};
 use opensearch::indices::IndicesGetAliasParts;
 use opensearch::{OpenSearch, auth::Credentials};
 use reqwest::StatusCode;
+use reqwest::header::{AUTHORIZATION, HeaderValue};
 
 impl ElasticsearchProvider {
   pub async fn new<'o>(url: &str, options: EsOptions<'o>) -> Result<ElasticsearchProvider, MotivaError> {
@@ -28,6 +29,7 @@ impl ElasticsearchProvider {
         EsAuthMethod::Basic(username, password) => transport.auth(Credentials::Basic(username, password)),
         EsAuthMethod::Bearer(token) => transport.auth(Credentials::Bearer(token)),
         EsAuthMethod::ApiKey(client_id, client_secret) => transport.auth(Credentials::ApiKey(client_id, client_secret)),
+        EsAuthMethod::ApiToken(token) => transport.header(AUTHORIZATION, HeaderValue::from_str(&format!("ApiKey {token}")).context("invalid index API token")?),
 
         #[cfg(feature = "aws")]
         EsAuthMethod::AwsIam(service) => {
@@ -77,6 +79,7 @@ impl ElasticsearchProvider {
       .get_alias(IndicesGetAliasParts::Index(&[&self.scoped_alias_name()]))
       .send()
       .await
+      .inspect_err(|err| tracing::warn!(error = %err, index = self.scoped_alias_name(), "could not check for scoped index alias"))
       .map(|resp| resp.status_code())
       .unwrap_or(StatusCode::NOT_FOUND);
 
@@ -98,8 +101,10 @@ pub enum EsAuthMethod {
   Basic(String, String),
   /// Bearer token
   Bearer(String),
-  /// API key (client ID and API key)
+  /// Elasticsearch API key (client ID and API key)
   ApiKey(String, String),
+  /// A single opaque OpenSearch API token.
+  ApiToken(String),
 
   #[cfg(feature = "aws")]
   /// AWS IAM
@@ -145,6 +150,55 @@ mod tests {
     prelude::{ElasticsearchProvider, EsAuthMethod},
   };
   use opensearch::OpenSearch;
+
+  async fn captured_authorization(auth: EsAuthMethod) -> String {
+    use serde_json::json;
+    use wiremock::{
+      Mock, MockServer, ResponseTemplate,
+      matchers::{method, path},
+    };
+
+    let server = MockServer::start().await;
+
+    Mock::given(method("HEAD")).and(path("/yente-entities")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+
+    Mock::given(method("GET"))
+      .and(path("/yente-entities/_mapping"))
+      .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+          "yente-entities": { "mappings": { "_source": { "excludes": ["name_keys"] } } }
+      })))
+      .mount(&server)
+      .await;
+
+    ElasticsearchProvider::new(&server.uri(), EsOptions { auth, ..Default::default() }).await.unwrap();
+
+    let request = server.received_requests().await.unwrap().into_iter().next().expect("no request reached the mock server");
+
+    request.headers.get("authorization").expect("no authorization header was sent").to_str().unwrap().to_string()
+  }
+
+  #[tokio::test]
+  async fn basic() {
+    assert_eq!(
+      captured_authorization(EsAuthMethod::Basic("username".to_string(), "password".to_string())).await,
+      "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+    );
+  }
+
+  #[tokio::test]
+  async fn bearer() {
+    assert_eq!(captured_authorization(EsAuthMethod::Bearer("key".to_string())).await, "Bearer key");
+  }
+
+  #[tokio::test]
+  async fn api_key() {
+    assert_eq!(captured_authorization(EsAuthMethod::ApiKey("id".to_string(), "key".to_string())).await, "ApiKey aWQ6a2V5");
+  }
+
+  #[tokio::test]
+  async fn api_token() {
+    assert_eq!(captured_authorization(EsAuthMethod::ApiToken("os_test_token".to_string())).await, "ApiKey os_test_token");
+  }
 
   #[tokio::test]
   async fn es_builder() {
@@ -302,6 +356,8 @@ mod tests {
     async fn request(service: AwsService) -> (String, Request) {
       let server = MockServer::start().await;
 
+      Mock::given(method("HEAD")).and(path("/yente-entities")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+
       Mock::given(method("GET"))
         .and(path("/yente-entities/_mapping"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -401,13 +457,13 @@ mod tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn signs_requests_for_managed_service() {
+    async fn aws_sigv4_opensearch_service() {
       temp_env::async_with_vars(AWS_ENV, assert_request_is_signed(AwsService::Service, "es")).await;
     }
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn signs_requests_for_serverless() {
+    async fn aws_sigv4_opensearch_serverless() {
       temp_env::async_with_vars(AWS_ENV, assert_request_is_signed(AwsService::Serverless, "aoss")).await;
     }
   }

--- a/crates/libmotiva/src/index/elastic/config.rs
+++ b/crates/libmotiva/src/index/elastic/config.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, sync::PoisonError};
 
 use ahash::HashMap;
-use elasticsearch::indices::IndicesGetMappingParts;
+use opensearch::indices::IndicesGetMappingParts;
 use reqwest::StatusCode;
 use serde::Deserialize;
 
@@ -107,8 +107,8 @@ impl ElasticsearchProvider {
 
 #[cfg(test)]
 mod tests {
-  use elasticsearch::{
-    Elasticsearch,
+  use opensearch::{
+    OpenSearch,
     http::{
       Url,
       transport::{SingleNodeConnectionPool, TransportBuilder},
@@ -138,7 +138,7 @@ mod tests {
     let transport = TransportBuilder::new(SingleNodeConnectionPool::new(url)).build().unwrap();
 
     ElasticsearchProvider {
-      es: Elasticsearch::new(transport),
+      es: OpenSearch::new(transport),
       index_prefix: "yente".to_string(),
       main_index: "yente-entities".to_string(),
       state: Arc::new(RwLock::new(IndexState {

--- a/crates/libmotiva/src/index/elastic/config.rs
+++ b/crates/libmotiva/src/index/elastic/config.rs
@@ -206,8 +206,8 @@ mod tests {
       .mount(&server)
       .await;
 
-    Mock::given(method("GET"))
-      .and(path("/_cluster/health/yente-entities"))
+    Mock::given(method("HEAD"))
+      .and(path("/yente-entities"))
       .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "status": "yellow" })))
       .mount(&server)
       .await;
@@ -233,8 +233,8 @@ mod tests {
       .mount(&server)
       .await;
 
-    Mock::given(method("GET"))
-      .and(path("/_cluster/health/yente-entities"))
+    Mock::given(method("HEAD"))
+      .and(path("/yente-entities"))
       .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "status": "green" })))
       .mount(&server)
       .await;

--- a/crates/libmotiva/src/index/elastic/config.rs
+++ b/crates/libmotiva/src/index/elastic/config.rs
@@ -164,6 +164,8 @@ mod tests {
         index_version: IndexVersion::V4,
         scoped_index: None,
       })),
+      #[cfg(feature = "aws")]
+      serverless: false,
     }
   }
 
@@ -224,8 +226,8 @@ mod tests {
       .mount(&server)
       .await;
 
-    Mock::given(method("HEAD"))
-      .and(path("/yente-entities"))
+    Mock::given(method("GET"))
+      .and(path("/_cluster/health/yente-entities"))
       .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "status": "yellow" })))
       .mount(&server)
       .await;
@@ -251,8 +253,8 @@ mod tests {
       .mount(&server)
       .await;
 
-    Mock::given(method("HEAD"))
-      .and(path("/yente-entities"))
+    Mock::given(method("GET"))
+      .and(path("/_cluster/health/yente-entities"))
       .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "status": "green" })))
       .mount(&server)
       .await;
@@ -273,14 +275,65 @@ mod tests {
 
   #[tokio::test]
   async fn refresh_index_state_not_ready() {
+    // Missing index (empty mock).
     let server = MockServer::start().await;
-
-    // Missing index: the health check (HEAD) has no matching mock, so wiremock
-    // returns 404, health() reports unhealthy, and we never reach mapping detection.
     let provider = provider(&server);
+
     provider.refresh_index_state().await;
 
     assert!(!provider.ready());
     assert_eq!(provider.state.read().unwrap().scoped_index, None);
+  }
+
+  #[tokio::test]
+  async fn refresh_index_state_red_index() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+      .and(path("/yente-entities/_mapping"))
+      .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+          "yente-entities": { "mappings": { "_source": { "excludes": ["name_keys"] } } }
+      })))
+      .mount(&server)
+      .await;
+
+    Mock::given(method("HEAD")).and(path("/yente-entities")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+
+    Mock::given(method("GET"))
+      .and(path("/_cluster/health/yente-entities"))
+      .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "status": "red" })))
+      .mount(&server)
+      .await;
+
+    let provider = provider(&server);
+    provider.refresh_index_state().await;
+
+    assert!(!provider.ready());
+  }
+
+  #[cfg(feature = "aws")]
+  #[tokio::test]
+  async fn refresh_index_state_serverless_uses_index_exists() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+      .and(path("/yente-entities/_mapping"))
+      .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+          "yente-entities": { "mappings": { "_source": { "excludes": ["name_keys"] } } }
+      })))
+      .mount(&server)
+      .await;
+
+    Mock::given(method("HEAD")).and(path("/yente-entities")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+
+    let provider = ElasticsearchProvider {
+      serverless: true,
+      ..provider(&server)
+    };
+
+    provider.refresh_index_state().await;
+
+    assert!(provider.ready());
+    assert_eq!(provider.index_version(), IndexVersion::V4);
   }
 }

--- a/crates/libmotiva/src/index/elastic/config.rs
+++ b/crates/libmotiva/src/index/elastic/config.rs
@@ -51,19 +51,24 @@ pub(crate) struct MappingIndexSource {
 
 impl ElasticsearchProvider {
   pub(crate) async fn refresh_index_state(&self) {
-    let (ready, version, scoped_index) = match self.detect_index_version().await {
-      Ok(version) => {
-        let healthy = self.health().await.unwrap_or(false);
-        let scoped_index = if healthy { self.detect_scoped_index().await } else { None };
+    let (ready, version, scoped_index) = if self.health().await.unwrap_or(false) {
+      match self.detect_index_version().await {
+        Ok(version) => {
+          let scoped_index = self.detect_scoped_index().await;
 
-        (healthy, version, scoped_index)
+          (true, version, scoped_index)
+        }
+
+        Err(err) => {
+          tracing::warn!(error = err.to_string(), index = self.main_index, "index is not ready");
+
+          (false, self.index_version(), None)
+        }
       }
+    } else {
+      tracing::warn!(index = self.main_index, "index is not healthy");
 
-      Err(err) => {
-        tracing::warn!(error = err.to_string(), index = self.main_index, "index is not ready");
-
-        (false, self.index_version(), None)
-      }
+      (false, self.index_version(), None)
     };
 
     {
@@ -82,13 +87,24 @@ impl ElasticsearchProvider {
   }
 
   pub(crate) async fn detect_index_version(&self) -> Result<IndexVersion, MotivaError> {
-    let mappings = self.es.indices().get_mapping(IndicesGetMappingParts::Index(&[&self.main_index])).send().await?;
+    let mappings = self
+      .es
+      .indices()
+      .get_mapping(IndicesGetMappingParts::Index(&[&self.main_index]))
+      .send()
+      .await
+      .inspect_err(|err| tracing::warn!(error = %err, index = self.main_index, "could not fetch index mapping"))?;
 
     if mappings.status_code() != StatusCode::OK {
+      tracing::warn!(status = %mappings.status_code(), index = self.main_index, "index mapping request returned an unexpected status code");
+
       Err(MotivaError::MissingIndex(self.main_index.to_string()))?
     }
 
-    let mappings: HashMap<String, MappingIndex> = mappings.json().await?;
+    let mappings: HashMap<String, MappingIndex> = mappings
+      .json()
+      .await
+      .inspect_err(|err| tracing::warn!(error = %err, index = self.main_index, "could not parse index mapping response"))?;
 
     for (_, index) in mappings {
       if index.mappings.source.excludes.contains(&"name_symbols".to_string()) {
@@ -100,6 +116,8 @@ impl ElasticsearchProvider {
         return Ok(IndexVersion::V4);
       }
     }
+
+    tracing::warn!(index = self.main_index, "index has an unrecognized mapping");
 
     Err(MotivaError::OtherError(anyhow::anyhow!("index {} has an unrecognized mapping", self.main_index)))
   }
@@ -257,14 +275,8 @@ mod tests {
   async fn refresh_index_state_not_ready() {
     let server = MockServer::start().await;
 
-    // Missing index: the mapping probe returns 404, so we never reach the health
-    // check and the provider stays not-ready.
-    Mock::given(method("GET"))
-      .and(path("/yente-entities/_mapping"))
-      .respond_with(ResponseTemplate::new(404))
-      .mount(&server)
-      .await;
-
+    // Missing index: the health check (HEAD) has no matching mock, so wiremock
+    // returns 404, health() reports unhealthy, and we never reach mapping detection.
     let provider = provider(&server);
     provider.refresh_index_state().await;
 

--- a/crates/libmotiva/src/index/elastic/mod.rs
+++ b/crates/libmotiva/src/index/elastic/mod.rs
@@ -11,8 +11,8 @@ use std::{
 };
 
 use ahash::RandomState;
-use elasticsearch::Elasticsearch;
 use jiff::civil::DateTime;
+use opensearch::OpenSearch;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -35,7 +35,7 @@ pub(crate) struct IndexState {
 /// Main index provider using Elasticsearch
 #[derive(Clone)]
 pub struct ElasticsearchProvider {
-  pub es: Elasticsearch,
+  pub es: OpenSearch,
   pub(crate) index_prefix: String,
   pub(crate) main_index: String,
   pub(crate) state: Arc<RwLock<IndexState>>,
@@ -178,7 +178,7 @@ pub(crate) struct EsEntitySource {
 mod tests {
   use std::collections::HashMap;
 
-  use elasticsearch::Elasticsearch;
+  use opensearch::OpenSearch;
 
   use crate::{
     ElasticsearchProvider,
@@ -216,7 +216,7 @@ mod tests {
     use crate::index::elastic::IndexState;
 
     let p = ElasticsearchProvider {
-      es: Elasticsearch::default(),
+      es: OpenSearch::default(),
       index_prefix: "myprefix".to_string(),
       main_index: "myprefix-entities".to_string(),
       state: Arc::new(RwLock::new(IndexState {

--- a/crates/libmotiva/src/index/elastic/mod.rs
+++ b/crates/libmotiva/src/index/elastic/mod.rs
@@ -57,11 +57,6 @@ impl ElasticsearchProvider {
 }
 
 #[derive(Deserialize)]
-struct EsHealth {
-  status: String,
-}
-
-#[derive(Deserialize)]
 struct EsErrorResponse {
   error: EsError,
 }

--- a/crates/libmotiva/src/index/elastic/mod.rs
+++ b/crates/libmotiva/src/index/elastic/mod.rs
@@ -39,6 +39,8 @@ pub struct ElasticsearchProvider {
   pub(crate) index_prefix: String,
   pub(crate) main_index: String,
   pub(crate) state: Arc<RwLock<IndexState>>,
+  #[cfg(feature = "aws")]
+  pub(crate) serverless: bool,
 }
 
 impl ElasticsearchProvider {
@@ -54,6 +56,11 @@ impl ElasticsearchProvider {
       None => Cow::Borrowed(&self.main_index),
     }
   }
+}
+
+#[derive(Deserialize)]
+struct EsHealth {
+  status: String,
 }
 
 #[derive(Deserialize)]
@@ -219,6 +226,8 @@ mod tests {
         index_version: IndexVersion::V5,
         scoped_index: None,
       })),
+      #[cfg(feature = "aws")]
+      serverless: false,
     };
 
     assert_eq!(p.index_name(IndexType::Main), "myprefix-entities");

--- a/crates/libmotiva/src/index/elastic/queries.rs
+++ b/crates/libmotiva/src/index/elastic/queries.rs
@@ -7,7 +7,11 @@ use ahash::RandomState;
 use anyhow::Context;
 use itertools::Itertools;
 use metrics::{counter, histogram};
-use opensearch::{SearchParts, cluster::ClusterHealthParts, indices::IndicesGetAliasParts, params::SearchType};
+use opensearch::{
+  SearchParts,
+  indices::{IndicesExistsParts, IndicesGetAliasParts},
+  params::SearchType,
+};
 use opentelemetry::global;
 use reqwest::StatusCode;
 
@@ -21,7 +25,7 @@ use crate::{
   error::MotivaError,
   index::{
     EntityHandle, IndexProvider,
-    elastic::{EsEntity, EsErrorResponse, EsHealth, EsResponse, config::IndexVersion},
+    elastic::{EsEntity, EsErrorResponse, EsResponse, config::IndexVersion},
   },
   matching::{MatchParams, extractors},
   model::{Entity, ResolveSchemaLevel, SearchEntity},
@@ -56,8 +60,8 @@ impl IndexProvider for ElasticsearchProvider {
   async fn health(&self) -> Result<bool, MotivaError> {
     let Ok(health) = self
       .es
-      .cluster()
-      .health(ClusterHealthParts::Index(&[&self.main_index]))
+      .indices()
+      .exists(IndicesExistsParts::Index(&[&self.main_index]))
       .send()
       .await
       .context("could not get cluster health")
@@ -65,14 +69,7 @@ impl IndexProvider for ElasticsearchProvider {
       return Ok(false);
     };
 
-    let Ok(health): Result<EsHealth, _> = health.json().await.context("could not deserialize cluster health") else {
-      return Ok(false);
-    };
-
-    match health.status.as_str() {
-      "green" | "yellow" => Ok(true),
-      _ => Ok(false),
-    }
+    Ok(health.status_code() == StatusCode::OK)
   }
 
   /// Search for candidate entities matching input parameters.

--- a/crates/libmotiva/src/index/elastic/queries.rs
+++ b/crates/libmotiva/src/index/elastic/queries.rs
@@ -5,9 +5,9 @@ use std::{
 
 use ahash::RandomState;
 use anyhow::Context;
-use elasticsearch::{SearchParts, cluster::ClusterHealthParts, indices::IndicesGetAliasParts, params::SearchType};
 use itertools::Itertools;
 use metrics::{counter, histogram};
+use opensearch::{SearchParts, cluster::ClusterHealthParts, indices::IndicesGetAliasParts, params::SearchType};
 use opentelemetry::global;
 use reqwest::StatusCode;
 
@@ -957,7 +957,7 @@ mod tests {
     };
 
     let provider = ElasticsearchProvider {
-      es: elasticsearch::Elasticsearch::default(),
+      es: opensearch::OpenSearch::default(),
       index_prefix: "yente".to_string(),
       main_index: "yente-entities".to_string(),
       state: Arc::new(std::sync::RwLock::new(IndexState {

--- a/crates/libmotiva/src/index/elastic/queries.rs
+++ b/crates/libmotiva/src/index/elastic/queries.rs
@@ -6,11 +6,7 @@ use std::{
 use ahash::RandomState;
 use itertools::Itertools;
 use metrics::{counter, histogram};
-use opensearch::{
-  SearchParts,
-  indices::{IndicesExistsParts, IndicesGetAliasParts},
-  params::SearchType,
-};
+use opensearch::{SearchParts, cluster::ClusterHealthParts, indices::IndicesGetAliasParts, params::SearchType};
 use opentelemetry::global;
 use reqwest::StatusCode;
 
@@ -24,7 +20,7 @@ use crate::{
   error::MotivaError,
   index::{
     EntityHandle, IndexProvider,
-    elastic::{EsEntity, EsErrorResponse, EsResponse, config::IndexVersion},
+    elastic::{EsEntity, EsErrorResponse, EsHealth, EsResponse, config::IndexVersion},
   },
   matching::{MatchParams, extractors},
   model::{Entity, ResolveSchemaLevel, SearchEntity},
@@ -61,23 +57,47 @@ impl IndexProvider for ElasticsearchProvider {
   /// The cluster will only be considered healthy if the index is `green` or `yellow`.
   #[instrument(skip_all)]
   async fn health(&self) -> Result<bool, MotivaError> {
+    #[cfg(feature = "aws")]
+    // OpenSearch Serverless does not expose the cluster health API, so collections
+    // fall back to probing the index's existence. That probe only reads cluster
+    // metadata, so a degraded index cannot be detected there.
+    if self.serverless {
+      return self.index_exists().await;
+    }
+
     let Ok(health) = self
       .es
-      .indices()
-      .exists(IndicesExistsParts::Index(&[&self.main_index]))
+      .cluster()
+      .health(ClusterHealthParts::Index(&[&self.main_index]))
       .send()
       .await
-      .inspect_err(|err| tracing::warn!(error = %err, index = self.main_index, "could not reach index to check its health"))
+      .inspect_err(|err| tracing::warn!(error = %err, index = self.main_index, "could not reach cluster to check index health"))
     else {
       return Ok(false);
     };
 
     if health.status_code() != StatusCode::OK {
-      tracing::warn!(status = %health.status_code(), index = self.main_index, "index health check returned an unexpected status code");
+      tracing::warn!(status = %health.status_code(), index = self.main_index, "cluster health request returned an unexpected status code");
       return Ok(false);
     }
 
-    Ok(true)
+    let Ok(health): Result<EsHealth, _> = health
+      .json()
+      .await
+      .inspect_err(|err| tracing::warn!(error = %err, index = self.main_index, "could not parse cluster health response"))
+    else {
+      return Ok(false);
+    };
+
+    match health.status.as_str() {
+      "green" | "yellow" => Ok(true),
+
+      status => {
+        tracing::warn!(status, index = self.main_index, "index is not in a healthy state");
+
+        Ok(false)
+      }
+    }
   }
 
   /// Search for candidate entities matching input parameters.
@@ -292,6 +312,32 @@ impl IndexProvider for ElasticsearchProvider {
         .map(|(field, values)| (field, values.buckets.iter().map(|bucket| bucket.key.to_string()).collect()))
         .collect(),
     )
+  }
+}
+
+impl ElasticsearchProvider {
+  #[cfg(feature = "aws")]
+  async fn index_exists(&self) -> Result<bool, MotivaError> {
+    use opensearch::indices::IndicesExistsParts;
+
+    let Ok(exists) = self
+      .es
+      .indices()
+      .exists(IndicesExistsParts::Index(&[&self.main_index]))
+      .send()
+      .await
+      .inspect_err(|err| tracing::warn!(error = %err, index = self.main_index, "could not reach index to check its health"))
+    else {
+      return Ok(false);
+    };
+
+    if exists.status_code() != StatusCode::OK {
+      tracing::warn!(status = %exists.status_code(), index = self.main_index, "index health check returned an unexpected status code");
+
+      return Ok(false);
+    }
+
+    Ok(true)
   }
 }
 
@@ -970,6 +1016,8 @@ mod tests {
         index_version: IndexVersion::V4,
         scoped_index: None,
       })),
+      #[cfg(feature = "aws")]
+      serverless: false,
     };
 
     let catalog = fake_catalog();

--- a/crates/libmotiva/src/index/elastic/queries.rs
+++ b/crates/libmotiva/src/index/elastic/queries.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use ahash::RandomState;
-use anyhow::Context;
 use itertools::Itertools;
 use metrics::{counter, histogram};
 use opensearch::{
@@ -38,7 +37,11 @@ impl IndexProvider for ElasticsearchProvider {
   fn after_init(&self) {
     let state = self.state.read().unwrap_or_else(PoisonError::into_inner);
 
-    tracing::info!(version = ?state.index_version, scoped_index = ?state.scoped_index, main_index = self.main_index, ready = state.ready, "detected yente version and index name");
+    if state.ready {
+      tracing::info!(version = ?state.index_version, scoped_index = ?state.scoped_index, main_index = self.main_index, "detected yente version and index name");
+    } else {
+      tracing::warn!(main_index = self.main_index, "index not ready at startup, deferring version detection and catalog initialization");
+    }
   }
 
   fn index_version(&self) -> IndexVersion {
@@ -64,12 +67,17 @@ impl IndexProvider for ElasticsearchProvider {
       .exists(IndicesExistsParts::Index(&[&self.main_index]))
       .send()
       .await
-      .context("could not get cluster health")
+      .inspect_err(|err| tracing::warn!(error = %err, index = self.main_index, "could not reach index to check its health"))
     else {
       return Ok(false);
     };
 
-    Ok(health.status_code() == StatusCode::OK)
+    if health.status_code() != StatusCode::OK {
+      tracing::warn!(status = %health.status_code(), index = self.main_index, "index health check returned an unexpected status code");
+      return Ok(false);
+    }
+
+    Ok(true)
   }
 
   /// Search for candidate entities matching input parameters.

--- a/crates/libmotiva/src/index/elastic/scoped.rs
+++ b/crates/libmotiva/src/index/elastic/scoped.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use anyhow::Context;
-use elasticsearch::indices::{IndicesCreateParts, IndicesDeleteParts, IndicesGetAliasParts, IndicesGetParts};
+use opensearch::indices::{IndicesCreateParts, IndicesDeleteParts, IndicesGetAliasParts, IndicesGetParts};
 use rand::distr::{Alphanumeric, SampleString};
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};

--- a/crates/libmotiva/src/lib.rs
+++ b/crates/libmotiva/src/lib.rs
@@ -37,6 +37,10 @@ pub mod prelude {
     EntityHandle, IndexProvider,
     elastic::{ElasticsearchProvider, builder::EsAuthMethod, builder::EsTlsVerification, config::EsOptions, scoped::create_scoped_index},
   };
+
+  #[cfg(feature = "aws")]
+  pub use crate::index::elastic::builder::AwsService;
+
   pub use crate::matching::{Algorithm, Feature, MatchParams, MatchingAlgorithm, logic_v1::LogicV1, marble_v0::MarbleV0, name_based::NameBased, name_qualified::NameQualified};
   pub use crate::model::{Entity, HasProperties, SearchEntity, format_score};
   pub use crate::scoring::ScoringOptions;

--- a/crates/libmotiva/src/motiva.rs
+++ b/crates/libmotiva/src/motiva.rs
@@ -279,6 +279,11 @@ impl<P: IndexProvider, F: CatalogFetcher> Motiva<P, F> {
     }
   }
 
+  /// Whether the locally cached catalog holds any dataset.
+  pub async fn has_catalog(&self) -> bool {
+    !self.catalog.read().await.datasets.is_empty()
+  }
+
   /// Return the merged catalog.
   ///
   /// By default, returns the cached merged dataset from the latest pull.
@@ -396,7 +401,11 @@ mod tests {
 
     let server = MockServer::start().await;
 
-    Mock::given(method("HEAD")).and(path("/yente-entities")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+    Mock::given(method("GET"))
+      .and(path("/_cluster/health/yente-entities"))
+      .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "status": "green" })))
+      .mount(&server)
+      .await;
 
     Mock::given(method("GET"))
       .and(path("/yente-entities/_mapping"))
@@ -424,6 +433,8 @@ mod tests {
         index_version: IndexVersion::V4,
         scoped_index: None,
       })),
+      #[cfg(feature = "aws")]
+      serverless: false,
     };
 
     let mut catalogs = HashMap::default();

--- a/crates/libmotiva/src/motiva.rs
+++ b/crates/libmotiva/src/motiva.rs
@@ -96,6 +96,10 @@ pub struct Motiva<P: IndexProvider, F: CatalogFetcher = HttpCatalogFetcher> {
 /// aborting startup. The background refresh loop recovers it once the index and
 /// upstream become available.
 async fn init_catalog<P: IndexProvider, F: CatalogFetcher>(fetcher: &F, provider: &P, outdated_grace: Span) -> Catalog {
+  if !provider.ready() {
+    return Catalog::default();
+  }
+
   match get_merged_catalog(fetcher, provider, outdated_grace).await {
     Ok(catalog) => catalog,
 
@@ -204,7 +208,13 @@ impl<P: IndexProvider, F: CatalogFetcher> Motiva<P, F> {
   /// Meant to be called periodically from a background task so the index can
   /// recover once it becomes available.
   pub async fn refresh(&self) {
+    let was_ready = self.index.ready();
+
     self.index.refresh().await;
+
+    if !was_ready && self.index.ready() {
+      self.refresh_catalog().await;
+    }
   }
 
   /// Get the detected index version.
@@ -360,5 +370,101 @@ mod tests {
     let motiva = Motiva::test(index).build().await.unwrap();
 
     assert!(motiva.get_catalog(false).await.unwrap().datasets.is_empty());
+  }
+
+  #[tokio::test]
+  async fn refresh_synchronously_rebuilds_catalog_on_recovery() {
+    use std::sync::{Arc, RwLock};
+
+    use opensearch::{
+      OpenSearch,
+      http::{
+        Url,
+        transport::{SingleNodeConnectionPool, TransportBuilder},
+      },
+    };
+    use serde_json::json;
+    use wiremock::{
+      Mock, MockServer, ResponseTemplate,
+      matchers::{method, path},
+    };
+
+    use crate::{
+      ElasticsearchProvider,
+      index::elastic::{IndexState, config::IndexVersion},
+    };
+
+    let server = MockServer::start().await;
+
+    Mock::given(method("HEAD")).and(path("/yente-entities")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+
+    Mock::given(method("GET"))
+      .and(path("/yente-entities/_mapping"))
+      .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+          "yente-entities": { "mappings": { "_source": { "excludes": ["name_keys"] } } }
+      })))
+      .mount(&server)
+      .await;
+
+    Mock::given(method("GET"))
+      .and(path("/_alias/yente-entities"))
+      .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+      .mount(&server)
+      .await;
+
+    let url = Url::parse(&server.uri()).unwrap();
+    let transport = TransportBuilder::new(SingleNodeConnectionPool::new(url)).build().unwrap();
+
+    let provider = ElasticsearchProvider {
+      es: OpenSearch::new(transport),
+      index_prefix: "yente".to_string(),
+      main_index: "yente-entities".to_string(),
+      state: Arc::new(RwLock::new(IndexState {
+        ready: false,
+        index_version: IndexVersion::V4,
+        scoped_index: None,
+      })),
+    };
+
+    let mut catalogs = HashMap::default();
+    catalogs.insert(
+      "dummyurl".to_string(),
+      Catalog {
+        datasets: vec![CatalogDataset {
+          name: "dataset1".to_string(),
+          ..Default::default()
+        }],
+        ..Default::default()
+      },
+    );
+
+    let fetcher = TestFetcher {
+      manifest: Manifest {
+        catalogs: vec![ManifestCatalog {
+          url: "dummyurl".to_string(),
+          ..Default::default()
+        }],
+        ..Default::default()
+      },
+      catalogs,
+    };
+
+    // The provider starts not-ready, so the initial synchronous catalog build
+    // at construction time is skipped, without ever hitting the mock server.
+    let motiva = Motiva::custom(provider).fetcher(fetcher).build().await.unwrap();
+
+    assert!(!motiva.ready());
+    assert!(motiva.get_catalog(false).await.is_err());
+
+    // A single refresh() call both detects recovery and, in the same call,
+    // synchronously rebuilds the catalog -- no separate refresh_catalog() needed.
+    motiva.refresh().await;
+
+    assert!(motiva.ready());
+
+    let catalog = motiva.get_catalog(false).await.unwrap();
+
+    assert_eq!(catalog.datasets.len(), 1);
+    assert!(catalog.datasets.iter().any(|ds| ds.name == "dataset1"));
   }
 }

--- a/crates/motiva/Cargo.toml
+++ b/crates/motiva/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://github.com/apognu/motiva"
 repository = "https://github.com/apognu/motiva"
 
 [features]
+aws = ["libmotiva/aws"]
 gcp = ["gcp_auth", "opentelemetry-gcloud-trace"]
 benchmarks = []
 

--- a/crates/motiva/Cargo.toml
+++ b/crates/motiva/Cargo.toml
@@ -18,6 +18,7 @@ anyhow = "1.0.98"
 axum = { version = "0.8.4", features = ["macros"] }
 axum-extra = { version = "0.12.5", features = ["query", "typed-header"] }
 axum-macros = "0.5.0"
+base64 = "0.23.1"
 gcp_auth = { version = "0.12.3", features = ["aws-lc-rs"], optional = true }
 itertools = "0.15.0"
 jiff = { version = "0.2.15", features = ["serde"] }

--- a/crates/motiva/Cargo.toml
+++ b/crates/motiva/Cargo.toml
@@ -75,6 +75,7 @@ nix = { version = "0.31.2", features = ["signal"] }
 rusty-fork = "0.3.1"
 serde-json-assert = "0.4.0"
 serial_test = "4.0"
+temp-env = { version = "0.3.6", features = ["async_closure"] }
 
 [lints]
 workspace = true

--- a/crates/motiva/src/api/config.rs
+++ b/crates/motiva/src/api/config.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use anyhow::Context;
+use base64::Engine;
 use jiff::Span;
 use libmotiva::{EsTlsVerification, GetEntityLimits, prelude::EsAuthMethod};
 use tokio::net::TcpListener;
@@ -109,13 +110,29 @@ impl FromStr for WrappedEsAuthMethod {
       "basic" if client_id.is_some() && client_secret.is_some() => EsAuthMethod::Basic(client_id.unwrap(), client_secret.unwrap()),
       "bearer" if client_secret.is_some() => EsAuthMethod::Bearer(client_secret.unwrap()),
       "api_key" if client_id.is_some() && client_secret.is_some() => EsAuthMethod::ApiKey(client_id.unwrap(), client_secret.unwrap()),
-      "encoded_api_key" if client_secret.is_some() => EsAuthMethod::EncodedApiKey(client_secret.unwrap()),
+
+      "encoded_api_key" if client_secret.is_some() => {
+        let (client_id, client_secret) = encoded_api_key(&client_secret.unwrap())?;
+
+        EsAuthMethod::ApiKey(client_id, client_secret)
+      }
 
       "basic" | "bearer" | "api_key" | "encoded_api_key" => Err(AppError::ConfigError("chosen index authentication method is missing a credential setting".into()))?,
 
       _ => Err(AppError::ConfigError("invalid elasticsearch authentication method".into()))?,
     }))
   }
+}
+
+fn encoded_api_key(value: &str) -> anyhow::Result<(String, String)> {
+  use base64::engine::general_purpose::STANDARD;
+
+  let value = STANDARD.decode(value)?;
+  let value = String::from_utf8(value)?;
+
+  let (username, password) = value.split_once(':').ok_or(anyhow::anyhow!("invalid shape for encoded api key"))?;
+
+  Ok((username.to_string(), password.to_string()))
 }
 
 #[derive(Clone, Debug, Default)]
@@ -224,7 +241,7 @@ mod tests {
       env::set_var("YENTE_URL", "http://yente");
       env::set_var("INDEX_URL", "http://index");
       env::set_var("INDEX_AUTH_METHOD", "encoded_api_key");
-      env::set_var("INDEX_CLIENT_SECRET", "secret");
+      env::set_var("INDEX_CLIENT_SECRET", "dXNlcm5hbWU6cGFzc3dvcmQ=");
       env::set_var("ENABLE_TRACING", "1");
     }
 
@@ -234,7 +251,7 @@ mod tests {
     assert_eq!(config.listen_addr, "0.0.0.0:8080");
     assert_eq!(config.match_candidates, 3);
     assert_eq!(config.index_url, "http://index");
-    assert_eq!(config.index_auth_method, EsAuthMethod::EncodedApiKey("secret".to_string()));
+    assert_eq!(config.index_auth_method, EsAuthMethod::ApiKey("username".to_string(), "password".to_string()));
     assert!(config.enable_tracing);
 
     unsafe {
@@ -333,7 +350,12 @@ mod tests {
     assert!(matches!("basic".parse::<WrappedEsAuthMethod>(), Ok(WrappedEsAuthMethod(EsAuthMethod::Basic(_, _)))));
     assert!(matches!("bearer".parse::<WrappedEsAuthMethod>(), Ok(WrappedEsAuthMethod(EsAuthMethod::Bearer(_)))));
     assert!(matches!("api_key".parse::<WrappedEsAuthMethod>(), Ok(WrappedEsAuthMethod(EsAuthMethod::ApiKey(_, _)))));
-    assert!(matches!("encoded_api_key".parse::<WrappedEsAuthMethod>(), Ok(WrappedEsAuthMethod(EsAuthMethod::EncodedApiKey(_)))));
+
+    unsafe {
+      env::set_var("INDEX_CLIENT_SECRET", "dXNlcm5hbWU6cGFzc3dvcmQ=");
+    }
+
+    assert!(matches!("encoded_api_key".parse::<WrappedEsAuthMethod>(), Ok(WrappedEsAuthMethod(EsAuthMethod::ApiKey(_, _)))));
 
     assert!("other".parse::<WrappedEsAuthMethod>().is_err());
 

--- a/crates/motiva/src/api/config.rs
+++ b/crates/motiva/src/api/config.rs
@@ -230,10 +230,7 @@ async fn detect_gcp_project_id() -> String {
 
 #[cfg(test)]
 mod tests {
-  use std::{
-    env,
-    net::{IpAddr, Ipv4Addr},
-  };
+  use std::net::{IpAddr, Ipv4Addr};
 
   use crate::api::config::WrappedEsAuthMethod;
 
@@ -242,128 +239,87 @@ mod tests {
   #[serial_test::serial]
   #[tokio::test]
   async fn parse_config_from_env() {
-    unsafe {
-      env::set_var("ENV", "production");
-      env::set_var("LISTEN_ADDR", "0.0.0.0:8080");
-      env::set_var("MATCH_CANDIDATES", "3");
-      env::set_var("YENTE_URL", "http://yente");
-      env::set_var("INDEX_URL", "http://index");
-      env::set_var("INDEX_AUTH_METHOD", "encoded_api_key");
-      env::set_var("INDEX_CLIENT_SECRET", "dXNlcm5hbWU6cGFzc3dvcmQ=");
-      env::set_var("ENABLE_TRACING", "1");
-    }
+    let vars = [
+      ("ENV", Some("production")),
+      ("LISTEN_ADDR", Some("0.0.0.0:8080")),
+      ("MATCH_CANDIDATES", Some("3")),
+      ("YENTE_URL", Some("http://yente")),
+      ("INDEX_URL", Some("http://index")),
+      ("INDEX_AUTH_METHOD", Some("encoded_api_key")),
+      ("INDEX_CLIENT_SECRET", Some("dXNlcm5hbWU6cGFzc3dvcmQ=")),
+      ("ENABLE_TRACING", Some("1")),
+    ];
 
-    let config = Config::from_env().await.unwrap();
+    temp_env::async_with_vars(vars, async {
+      let config = Config::from_env().await.unwrap();
 
-    assert_eq!(config.env, Env::Production);
-    assert_eq!(config.listen_addr, "0.0.0.0:8080");
-    assert_eq!(config.match_candidates, 3);
-    assert_eq!(config.index_url, "http://index");
-    assert_eq!(config.index_auth_method, EsAuthMethod::ApiKey("username".to_string(), "password".to_string()));
-    assert!(config.enable_tracing);
-
-    unsafe {
-      env::remove_var("ENV");
-      env::remove_var("LISTEN_ADDR");
-      env::remove_var("MATCH_CANDIDATES");
-      env::remove_var("YENTE_URL");
-      env::remove_var("INDEX_URL");
-      env::remove_var("INDEX_AUTH_METHOD");
-      env::remove_var("INDEX_CLIENT_SECRET");
-      env::remove_var("ENABLE_TRACING");
-    }
+      assert_eq!(config.env, Env::Production);
+      assert_eq!(config.listen_addr, "0.0.0.0:8080");
+      assert_eq!(config.match_candidates, 3);
+      assert_eq!(config.index_url, "http://index");
+      assert_eq!(config.index_auth_method, EsAuthMethod::ApiKey("username".to_string(), "password".to_string()));
+      assert!(config.enable_tracing);
+    })
+    .await;
   }
 
   #[tokio::test]
   #[serial_test::serial]
   async fn invalid_es_auth_method_combination() {
-    unsafe {
-      env::set_var("INDEX_AUTH_METHOD", "basic");
-      env::set_var("INDEX_CLIENT_SECRET", "secret");
+    for method in ["basic", "api_key"] {
+      temp_env::async_with_vars([("INDEX_AUTH_METHOD", Some(method)), ("INDEX_CLIENT_ID", None), ("INDEX_CLIENT_SECRET", Some("secret"))], async {
+        assert!(Config::from_env().await.is_err());
+      })
+      .await;
     }
 
-    assert!(Config::from_env().await.is_err());
+    temp_env::async_with_vars(
+      [("INDEX_AUTH_METHOD", Some("basic")), ("INDEX_CLIENT_ID", Some("secret")), ("INDEX_CLIENT_SECRET", Some("secret"))],
+      async {
+        let config = Config::from_env().await.unwrap();
 
-    unsafe {
-      env::set_var("INDEX_AUTH_METHOD", "api_key");
-      env::set_var("INDEX_CLIENT_SECRET", "secret");
-    }
+        assert_eq!(config.index_auth_method, EsAuthMethod::Basic("secret".to_string(), "secret".to_string()));
+      },
+    )
+    .await;
 
-    assert!(Config::from_env().await.is_err());
+    temp_env::async_with_vars(
+      [("INDEX_AUTH_METHOD", Some("api_key")), ("INDEX_CLIENT_ID", Some("secret")), ("INDEX_CLIENT_SECRET", Some("secret"))],
+      async {
+        let config = Config::from_env().await.unwrap();
 
-    unsafe {
-      env::set_var("INDEX_AUTH_METHOD", "basic");
-      env::set_var("INDEX_CLIENT_ID", "secret");
-      env::set_var("INDEX_CLIENT_SECRET", "secret");
-    }
-
-    let config = Config::from_env().await.unwrap();
-
-    assert_eq!(config.index_auth_method, EsAuthMethod::Basic("secret".to_string(), "secret".to_string()));
-
-    unsafe {
-      env::set_var("INDEX_AUTH_METHOD", "api_key");
-      env::set_var("INDEX_CLIENT_ID", "secret");
-      env::set_var("INDEX_CLIENT_SECRET", "secret");
-    }
-
-    let config = Config::from_env().await.unwrap();
-
-    assert_eq!(config.index_auth_method, EsAuthMethod::ApiKey("secret".to_string(), "secret".to_string()));
-
-    unsafe {
-      env::remove_var("INDEX_AUTH_METHOD");
-      env::remove_var("INDEX_CLIENT_ID");
-      env::remove_var("INDEX_CLIENT_SECRET");
-    }
+        assert_eq!(config.index_auth_method, EsAuthMethod::ApiKey("secret".to_string(), "secret".to_string()));
+      },
+    )
+    .await;
   }
 
   #[cfg(feature = "aws")]
   #[tokio::test]
+  #[serial_test::serial]
   async fn aws_iam() {
     use libmotiva::AwsService;
 
-    unsafe {
-      env::set_var("INDEX_AUTH_METHOD", "aws-iam-serverless");
-    }
+    for (value, expected) in [("aws-iam-serverless", AwsService::Serverless), ("aws-iam-service", AwsService::Service)] {
+      temp_env::async_with_vars([("INDEX_AUTH_METHOD", Some(value))], async {
+        let config = Config::from_env().await.unwrap();
 
-    let config = Config::from_env().await.unwrap();
-
-    assert_eq!(config.index_auth_method, EsAuthMethod::AwsIam(AwsService::Serverless));
-
-    unsafe {
-      env::set_var("INDEX_AUTH_METHOD", "aws-iam-service");
-    }
-
-    let config = Config::from_env().await.unwrap();
-
-    assert_eq!(config.index_auth_method, EsAuthMethod::AwsIam(AwsService::Service));
-
-    unsafe {
-      env::remove_var("INDEX_AUTH_METHOD");
+        assert_eq!(config.index_auth_method, EsAuthMethod::AwsIam(expected));
+      })
+      .await;
     }
   }
 
   #[test]
   #[serial_test::serial]
   fn parse_env() {
-    unsafe {
-      env::set_var("INT", "42");
-      env::set_var("BOOL", "true");
-      env::set_var("IP", "1.2.3.4");
-    }
+    temp_env::with_vars([("INT", Some("42")), ("BOOL", Some("true")), ("IP", Some("1.2.3.4"))], || {
+      assert_eq!(super::parse_env::<u32>("INT", 0).unwrap(), 42);
+      assert!(super::parse_env::<bool>("BOOL", true).unwrap());
+      assert_eq!(super::parse_env::<IpAddr>("IP", IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))).unwrap(), IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)));
 
-    assert_eq!(super::parse_env::<u32>("INT", 0).unwrap(), 42);
-    assert!(super::parse_env::<bool>("BOOL", true).unwrap());
-    assert_eq!(super::parse_env::<IpAddr>("IP", IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))).unwrap(), IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)));
-
-    assert!(super::parse_env::<u32>("BOOL", 0).is_err());
-
-    unsafe {
-      env::remove_var("INT");
-      env::remove_var("BOOL");
-      env::remove_var("IP");
-    }
+      assert!(super::parse_env::<u32>("BOOL", 0).is_err());
+    });
   }
 
   #[test]
@@ -375,28 +331,18 @@ mod tests {
   #[test]
   #[serial_test::serial]
   fn tracing_exporter_from_str() {
-    unsafe {
-      env::set_var("INDEX_CLIENT_ID", "secret");
-      env::set_var("INDEX_CLIENT_SECRET", "secret");
-    }
+    temp_env::with_vars([("INDEX_CLIENT_ID", Some("secret")), ("INDEX_CLIENT_SECRET", Some("secret"))], || {
+      assert!(matches!("none".parse::<WrappedEsAuthMethod>(), Ok(WrappedEsAuthMethod(EsAuthMethod::None))));
+      assert!(matches!("basic".parse::<WrappedEsAuthMethod>(), Ok(WrappedEsAuthMethod(EsAuthMethod::Basic(_, _)))));
+      assert!(matches!("bearer".parse::<WrappedEsAuthMethod>(), Ok(WrappedEsAuthMethod(EsAuthMethod::Bearer(_)))));
+      assert!(matches!("api_key".parse::<WrappedEsAuthMethod>(), Ok(WrappedEsAuthMethod(EsAuthMethod::ApiKey(_, _)))));
 
-    assert!(matches!("none".parse::<WrappedEsAuthMethod>(), Ok(WrappedEsAuthMethod(EsAuthMethod::None))));
-    assert!(matches!("basic".parse::<WrappedEsAuthMethod>(), Ok(WrappedEsAuthMethod(EsAuthMethod::Basic(_, _)))));
-    assert!(matches!("bearer".parse::<WrappedEsAuthMethod>(), Ok(WrappedEsAuthMethod(EsAuthMethod::Bearer(_)))));
-    assert!(matches!("api_key".parse::<WrappedEsAuthMethod>(), Ok(WrappedEsAuthMethod(EsAuthMethod::ApiKey(_, _)))));
+      assert!("other".parse::<WrappedEsAuthMethod>().is_err());
+    });
 
-    unsafe {
-      env::set_var("INDEX_CLIENT_SECRET", "dXNlcm5hbWU6cGFzc3dvcmQ=");
-    }
-
-    assert!(matches!("encoded_api_key".parse::<WrappedEsAuthMethod>(), Ok(WrappedEsAuthMethod(EsAuthMethod::ApiKey(_, _)))));
-
-    assert!("other".parse::<WrappedEsAuthMethod>().is_err());
-
-    unsafe {
-      env::remove_var("INDEX_CLIENT_ID");
-      env::remove_var("INDEX_CLIENT_SECRET");
-    }
+    temp_env::with_vars([("INDEX_CLIENT_ID", Some("secret")), ("INDEX_CLIENT_SECRET", Some("dXNlcm5hbWU6cGFzc3dvcmQ="))], || {
+      assert!(matches!("encoded_api_key".parse::<WrappedEsAuthMethod>(), Ok(WrappedEsAuthMethod(EsAuthMethod::ApiKey(_, _)))));
+    });
   }
 
   #[test]
@@ -412,75 +358,65 @@ mod tests {
   fn parse_index_tls() {
     use libmotiva::EsTlsVerification;
 
-    unsafe { env::set_var("INDEX_TLS_SKIP_VERIFY", "1") };
-    assert_eq!(super::parse_index_tls_verification().unwrap(), EsTlsVerification::SkipVerify);
-    unsafe { env::remove_var("INDEX_TLS_SKIP_VERIFY") };
+    temp_env::with_vars([("INDEX_TLS_SKIP_VERIFY", Some("1")), ("INDEX_TLS_CA_CERT", None)], || {
+      assert_eq!(super::parse_index_tls_verification().unwrap(), EsTlsVerification::SkipVerify);
+    });
 
-    unsafe { env::set_var("INDEX_TLS_CA_CERT", "Cargo.toml") };
-    assert!(matches!(super::parse_index_tls_verification().unwrap(), EsTlsVerification::CaCertChain(_)));
-    unsafe { env::remove_var("INDEX_TLS_CA_CERT") };
+    temp_env::with_vars([("INDEX_TLS_SKIP_VERIFY", None), ("INDEX_TLS_CA_CERT", Some("Cargo.toml"))], || {
+      assert!(matches!(super::parse_index_tls_verification().unwrap(), EsTlsVerification::CaCertChain(_)));
+    });
 
-    unsafe { env::set_var("INDEX_TLS_CA_CERT", "") };
-    assert_eq!(super::parse_index_tls_verification().unwrap(), EsTlsVerification::Default);
-    unsafe { env::remove_var("INDEX_TLS_CA_CERT") };
+    temp_env::with_vars([("INDEX_TLS_SKIP_VERIFY", None), ("INDEX_TLS_CA_CERT", Some(""))], || {
+      assert_eq!(super::parse_index_tls_verification().unwrap(), EsTlsVerification::Default);
+    });
 
-    assert_eq!(super::parse_index_tls_verification().unwrap(), EsTlsVerification::Default);
+    temp_env::with_vars_unset(["INDEX_TLS_SKIP_VERIFY", "INDEX_TLS_CA_CERT"], || {
+      assert_eq!(super::parse_index_tls_verification().unwrap(), EsTlsVerification::Default);
+    });
 
-    unsafe { env::set_var("INDEX_TLS_CA_CERT", "/nonexistent/path/to/cert.pem") };
-    assert!(super::parse_index_tls_verification().is_err());
-    unsafe { env::remove_var("INDEX_TLS_CA_CERT") };
+    temp_env::with_vars([("INDEX_TLS_SKIP_VERIFY", None), ("INDEX_TLS_CA_CERT", Some("/nonexistent/path/to/cert.pem"))], || {
+      assert!(super::parse_index_tls_verification().is_err());
+    });
   }
 
   #[test]
   #[serial_test::serial]
   fn parse_env_empty_returns_default() {
-    unsafe { env::set_var("MOTIVA_TEST_EMPTY", "") };
-    assert_eq!(super::parse_env::<u32>("MOTIVA_TEST_EMPTY", 7).unwrap(), 7);
-    unsafe { env::remove_var("MOTIVA_TEST_EMPTY") };
+    temp_env::with_var("MOTIVA_TEST_EMPTY", Some(""), || {
+      assert_eq!(super::parse_env::<u32>("MOTIVA_TEST_EMPTY", 7).unwrap(), 7);
+    });
   }
 
   #[test]
   #[serial_test::serial]
   fn es_auth_method_missing_credentials() {
-    unsafe {
-      env::remove_var("INDEX_CLIENT_ID");
-      env::remove_var("INDEX_CLIENT_SECRET");
-    }
-
-    assert!("bearer".parse::<WrappedEsAuthMethod>().is_err());
-    assert!("encoded_api_key".parse::<WrappedEsAuthMethod>().is_err());
+    temp_env::with_vars_unset(["INDEX_CLIENT_ID", "INDEX_CLIENT_SECRET"], || {
+      assert!("bearer".parse::<WrappedEsAuthMethod>().is_err());
+      assert!("encoded_api_key".parse::<WrappedEsAuthMethod>().is_err());
+    });
   }
 
   #[test]
   #[serial_test::serial]
   fn parse_weights() {
-    unsafe {
-      env::set_var("WEIGHT_POSITIVE", "0.1");
-      env::set_var("WEIGHT_NEGATIVE", "-0.7");
-      env::set_var("WEIGHT_LOWER_CLAMPED", "-2.0");
-      env::set_var("WEIGHT_HIGHER_CLAMPED", "2.0");
-    }
+    let weights = [
+      ("WEIGHT_POSITIVE", Some("0.1")),
+      ("WEIGHT_NEGATIVE", Some("-0.7")),
+      ("WEIGHT_LOWER_CLAMPED", Some("-2.0")),
+      ("WEIGHT_HIGHER_CLAMPED", Some("2.0")),
+    ];
 
-    let weights = super::parse_weights_from_env().unwrap();
+    temp_env::with_vars(weights, || {
+      let weights = super::parse_weights_from_env().unwrap();
 
-    assert!(matches!(weights.get("positive"), Some(0.1)));
-    assert!(matches!(weights.get("negative"), Some(-0.7)));
-    assert!(matches!(weights.get("lower_clamped"), Some(-1.0)));
-    assert!(matches!(weights.get("higher_clamped"), Some(1.0)));
+      assert!(matches!(weights.get("positive"), Some(0.1)));
+      assert!(matches!(weights.get("negative"), Some(-0.7)));
+      assert!(matches!(weights.get("lower_clamped"), Some(-1.0)));
+      assert!(matches!(weights.get("higher_clamped"), Some(1.0)));
+    });
 
-    unsafe {
-      env::remove_var("WEIGHT_POSITIVE");
-      env::remove_var("WEIGHT_NEGATIVE");
-      env::remove_var("WEIGHT_LOWER_CLAMPED");
-      env::remove_var("WEIGHT_HIGHER_CLAMPED");
-
-      env::set_var("WEIGHT_NAN", "nan");
-    }
-
-    assert!(super::parse_weights_from_env().is_err());
-
-    unsafe {
-      env::remove_var("WEIGHT_NAN");
-    }
+    temp_env::with_var("WEIGHT_NAN", Some("nan"), || {
+      assert!(super::parse_weights_from_env().is_err());
+    });
   }
 }

--- a/crates/motiva/src/api/config.rs
+++ b/crates/motiva/src/api/config.rs
@@ -12,6 +12,9 @@ use jiff::Span;
 use libmotiva::{EsTlsVerification, GetEntityLimits, prelude::EsAuthMethod};
 use tokio::net::TcpListener;
 
+#[cfg(feature = "aws")]
+use libmotiva::prelude::AwsService;
+
 use crate::api::errors::AppError;
 
 #[derive(Default, Debug)]
@@ -116,6 +119,11 @@ impl FromStr for WrappedEsAuthMethod {
 
         EsAuthMethod::ApiKey(client_id, client_secret)
       }
+
+      #[cfg(feature = "aws")]
+      "aws-iam-service" => EsAuthMethod::AwsIam(AwsService::Service),
+      #[cfg(feature = "aws")]
+      "aws-iam-serverless" => EsAuthMethod::AwsIam(AwsService::Serverless),
 
       "basic" | "bearer" | "api_key" | "encoded_api_key" => Err(AppError::ConfigError("chosen index authentication method is missing a credential setting".into()))?,
 
@@ -307,6 +315,32 @@ mod tests {
       env::remove_var("INDEX_AUTH_METHOD");
       env::remove_var("INDEX_CLIENT_ID");
       env::remove_var("INDEX_CLIENT_SECRET");
+    }
+  }
+
+  #[cfg(feature = "aws")]
+  #[tokio::test]
+  async fn aws_iam() {
+    use libmotiva::AwsService;
+
+    unsafe {
+      env::set_var("INDEX_AUTH_METHOD", "aws-iam-serverless");
+    }
+
+    let config = Config::from_env().await.unwrap();
+
+    assert_eq!(config.index_auth_method, EsAuthMethod::AwsIam(AwsService::Serverless));
+
+    unsafe {
+      env::set_var("INDEX_AUTH_METHOD", "aws-iam-service");
+    }
+
+    let config = Config::from_env().await.unwrap();
+
+    assert_eq!(config.index_auth_method, EsAuthMethod::AwsIam(AwsService::Service));
+
+    unsafe {
+      env::remove_var("INDEX_AUTH_METHOD");
     }
   }
 

--- a/crates/motiva/src/api/config.rs
+++ b/crates/motiva/src/api/config.rs
@@ -122,9 +122,9 @@ impl FromStr for WrappedEsAuthMethod {
       }
 
       #[cfg(feature = "aws")]
-      "aws-iam-service" => EsAuthMethod::AwsIam(AwsService::Service),
+      "aws_iam_service" => EsAuthMethod::AwsIam(AwsService::Service),
       #[cfg(feature = "aws")]
-      "aws-iam-serverless" => EsAuthMethod::AwsIam(AwsService::Serverless),
+      "aws_iam_serverless" => EsAuthMethod::AwsIam(AwsService::Serverless),
 
       "basic" | "bearer" | "api_key" | "encoded_api_key" | "api_token" => Err(AppError::ConfigError("chosen index authentication method is missing a credential setting".into()))?,
 
@@ -301,7 +301,7 @@ mod tests {
   async fn aws_iam() {
     use libmotiva::AwsService;
 
-    for (value, expected) in [("aws-iam-serverless", AwsService::Serverless), ("aws-iam-service", AwsService::Service)] {
+    for (value, expected) in [("aws_iam_serverless", AwsService::Serverless), ("aws_iam_service", AwsService::Service)] {
       temp_env::async_with_vars([("INDEX_AUTH_METHOD", Some(value))], async {
         let config = Config::from_env().await.unwrap();
 

--- a/crates/motiva/src/api/config.rs
+++ b/crates/motiva/src/api/config.rs
@@ -113,6 +113,7 @@ impl FromStr for WrappedEsAuthMethod {
       "basic" if client_id.is_some() && client_secret.is_some() => EsAuthMethod::Basic(client_id.unwrap(), client_secret.unwrap()),
       "bearer" if client_secret.is_some() => EsAuthMethod::Bearer(client_secret.unwrap()),
       "api_key" if client_id.is_some() && client_secret.is_some() => EsAuthMethod::ApiKey(client_id.unwrap(), client_secret.unwrap()),
+      "api_token" if client_secret.is_some() => EsAuthMethod::ApiToken(client_secret.unwrap()),
 
       "encoded_api_key" if client_secret.is_some() => {
         let (client_id, client_secret) = encoded_api_key(&client_secret.unwrap())?;
@@ -125,7 +126,7 @@ impl FromStr for WrappedEsAuthMethod {
       #[cfg(feature = "aws")]
       "aws-iam-serverless" => EsAuthMethod::AwsIam(AwsService::Serverless),
 
-      "basic" | "bearer" | "api_key" | "encoded_api_key" => Err(AppError::ConfigError("chosen index authentication method is missing a credential setting".into()))?,
+      "basic" | "bearer" | "api_key" | "encoded_api_key" | "api_token" => Err(AppError::ConfigError("chosen index authentication method is missing a credential setting".into()))?,
 
       _ => Err(AppError::ConfigError("invalid elasticsearch authentication method".into()))?,
     }))
@@ -336,6 +337,7 @@ mod tests {
       assert!(matches!("basic".parse::<WrappedEsAuthMethod>(), Ok(WrappedEsAuthMethod(EsAuthMethod::Basic(_, _)))));
       assert!(matches!("bearer".parse::<WrappedEsAuthMethod>(), Ok(WrappedEsAuthMethod(EsAuthMethod::Bearer(_)))));
       assert!(matches!("api_key".parse::<WrappedEsAuthMethod>(), Ok(WrappedEsAuthMethod(EsAuthMethod::ApiKey(_, _)))));
+      assert!(matches!("api_token".parse::<WrappedEsAuthMethod>(), Ok(WrappedEsAuthMethod(EsAuthMethod::ApiToken(_)))));
 
       assert!("other".parse::<WrappedEsAuthMethod>().is_err());
     });
@@ -393,6 +395,7 @@ mod tests {
     temp_env::with_vars_unset(["INDEX_CLIENT_ID", "INDEX_CLIENT_SECRET"], || {
       assert!("bearer".parse::<WrappedEsAuthMethod>().is_err());
       assert!("encoded_api_key".parse::<WrappedEsAuthMethod>().is_err());
+      assert!("api_token".parse::<WrappedEsAuthMethod>().is_err());
     });
   }
 

--- a/crates/motiva/src/api/mod.rs
+++ b/crates/motiva/src/api/mod.rs
@@ -45,17 +45,20 @@ pub async fn routes<F: CatalogFetcher, P: IndexProvider>(config: Config, fetcher
 
     async move {
       while !motiva.ready() {
-        motiva.refresh().await;
-
-        if motiva.ready() {
-          break;
-        }
-
         tokio::time::sleep(readiness_interval).await;
+
+        motiva.refresh().await;
       }
 
+      let mut due = !motiva.has_catalog().await;
+
       loop {
-        motiva.refresh_catalog().await;
+        if due {
+          motiva.refresh_catalog().await;
+        }
+
+        due = true;
+
         tokio::time::sleep(refresh_interval).await;
       }
     }

--- a/crates/motiva/src/main.rs
+++ b/crates/motiva/src/main.rs
@@ -27,6 +27,8 @@ async fn main() -> anyhow::Result<()> {
 
   let config = Config::from_env().await?;
 
+  let _guards = trace::init_tracing(&config, std::io::stdout()).await;
+
   let options = EsOptions {
     auth: config.index_auth_method.clone(),
     tls: &config.index_tls_verification,
@@ -36,8 +38,6 @@ async fn main() -> anyhow::Result<()> {
   let provider = ElasticsearchProvider::new(&config.index_url, options).await?;
 
   if let Some(cmd) = std::env::args().nth(1) {
-    let _guards = trace::init_tracing(&config, std::io::stdout()).await;
-
     match cmd.as_str() {
       "create-scoped-index" => oneoff::create_scoped_index(&provider).await?,
       _ => anyhow::bail!("unsupported command `{cmd}`"),
@@ -50,8 +50,6 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn run<P: IndexProvider>(mut config: Config, provider: P) -> anyhow::Result<()> {
-  let _guards = trace::init_tracing(&config, std::io::stdout()).await;
-
   let listener = match config.listener {
     Some(_) => config.listener.take().unwrap(),
     None => tokio::net::TcpListener::bind(&config.listen_addr).await.expect("could not create listener"),

--- a/crates/motiva/src/tests/e2e/specs/misc.hurl
+++ b/crates/motiva/src/tests/e2e/specs/misc.hurl
@@ -14,9 +14,9 @@ HTTP 200
 
 [Asserts]
 jsonpath "$.algorithms" isCollection
-jsonpath "$.algorithms[*].name" includes "logic-v1"
-jsonpath "$.algorithms[*].name" includes "name-based"
-jsonpath "$.algorithms[*].name" includes "name-qualified"
+jsonpath "$.algorithms[*].name" contains "logic-v1"
+jsonpath "$.algorithms[*].name" contains "name-based"
+jsonpath "$.algorithms[*].name" contains "name-qualified"
 jsonpath "$.best" == "logic-v1"
 jsonpath "$.default" == "logic-v1"
 


### PR DESCRIPTION
This PR swaps the official `elasticsearch-rs` crate for `opensearch` in preparation for the support of AWS's managed OpenSearch service. These crates has (_almost_) the same APIs, but `opensearch` supports AWS IAM authentication out of the box (behind a feature).

OpenSearch also adds a new authentication method, `API tokens`, that takes only a bare secret (as opposed to Elasticsearch `API key` which consist of a ID + key pair). We implement this as the `api_token` authentication method.

---

This PR also provides authentication to the OpenSearch cluster through AWS SigV4 signatures. This can be enabled through two new index auth methods, `INDEX_AUTH_METHOD=aws-iam-service` (for OpenSearch Service) and `INDEX_AUTH_METHOD=aws-iam-serverless` (for OpenSearch Serverless).

The region and credentials are detected automatically through the default provider chains.

---

Tested against:

- [x] Elasticsearch
- [x] OpenSearch OSS
- [x] OpenSearch Service
- [x] OpenSearch Serverless

Authentication tested with:

- [x] IAM user static keys
- [x] EC2 instance profile